### PR TITLE
フィードバック文章の修正

### DIFF
--- a/lib/register_page.dart
+++ b/lib/register_page.dart
@@ -99,7 +99,7 @@ class RegisterPageState extends State<RegisterPage> {
       if (e.code == "ERROR_EMAIL_ALREADY_IN_USE") {
         // トーストを表示
         Fluttertoast.showToast(
-          msg: 'ご入力されたEメールアドレスは既に使われています。',
+          msg: 'そのアドレスはもう使われてるよ',
         );
       }
     }

--- a/lib/register_page.dart
+++ b/lib/register_page.dart
@@ -49,6 +49,12 @@ class RegisterPageState extends State<RegisterPage> {
                 if (value.isEmpty) {
                   return 'パスワード入れて（怒）';
                 }
+                else if (validateIncludeNumber(value)){
+                  return '数字も混ぜてね';
+                }
+                else if (!validateLength(value)){
+                  return '8文字以上にしてね';
+                }
                 return null;
               },
               obscureText: true,
@@ -115,5 +121,17 @@ class RegisterPageState extends State<RegisterPage> {
         Navigator.pop(context, user);
       });
     } else {}
+  }
+
+  bool validateIncludeNumber(String value){
+    String  pattern = r'^\D+$';
+    RegExp regExp = new RegExp(pattern);
+    return regExp.hasMatch(value);
+  }
+
+  bool validateLength(String value){
+    String  pattern = r'^.{8,}$';
+    RegExp regExp = new RegExp(pattern);
+    return regExp.hasMatch(value);
   }
 }

--- a/lib/register_page.dart
+++ b/lib/register_page.dart
@@ -34,20 +34,20 @@ class RegisterPageState extends State<RegisterPage> {
           children: <Widget>[
             TextFormField(
               controller: _emailController,
-              decoration: const InputDecoration(labelText: 'Email'),
+              decoration: const InputDecoration(labelText: 'アドレスを入れてね'),
               validator: (String value) {
                 if (value.isEmpty) {
-                  return 'メールアドレスを入力してください';
+                  return 'アドレス入れて（怒）';
                 }
                 return null;
               },
             ),
             TextFormField(
               controller: _passwordController,
-              decoration: const InputDecoration(labelText: 'Password'),
+              decoration: const InputDecoration(labelText: 'パスワードを入れてね'),
               validator: (String value) {
                 if (value.isEmpty) {
-                  return 'パスワードを入力してください';
+                  return 'パスワード入れて（怒）';
                 }
                 return null;
               },

--- a/lib/signin_page.dart
+++ b/lib/signin_page.dart
@@ -121,7 +121,7 @@ class _EmailPasswordFormState extends State<_EmailPasswordForm> {
     } on PlatformException {
       // メールやパスの入力がおかしかったらトーストを表示
       Fluttertoast.showToast(
-        msg: 'ご入力されたパスワードもしくはメールアドレスに誤りがあります。',
+        msg: 'パスワードかアドレスが間違ってるよ',
       );
     }
 

--- a/lib/signin_page.dart
+++ b/lib/signin_page.dart
@@ -52,11 +52,6 @@ class _EmailPasswordFormState extends State<_EmailPasswordForm> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
-          Container(
-            child: const Text('メールアドレスとパスワードを入力してください'),
-            padding: const EdgeInsets.all(16),
-            alignment: Alignment.center,
-          ),
           TextFormField(
             controller: _emailController,
             decoration: const InputDecoration(labelText: 'アドレスを入れてね'),

--- a/lib/signin_page.dart
+++ b/lib/signin_page.dart
@@ -59,20 +59,20 @@ class _EmailPasswordFormState extends State<_EmailPasswordForm> {
           ),
           TextFormField(
             controller: _emailController,
-            decoration: const InputDecoration(labelText: 'Email'),
+            decoration: const InputDecoration(labelText: 'アドレスを入れてね'),
             validator: (String value) {
               if (value.isEmpty) {
-                return 'Please enter some text';
+                return 'アドレス入れて（怒）';
               }
               return null;
             },
           ),
           TextFormField(
             controller: _passwordController,
-            decoration: const InputDecoration(labelText: 'Password'),
+            decoration: const InputDecoration(labelText: 'パスワードを入れてね'),
             validator: (String value) {
               if (value.isEmpty) {
-                return 'Please enter some text';
+                return 'パスワード入れて（怒）';
               }
               return null;
             },


### PR DESCRIPTION
# バックログアイテムの情報
#47 #48

作成者：Takeda

テスター：@tyanio @Yamakatsu63 

## タスク
- [x] toastの文章を柔らかくする
- [x] プレースホルダーを日本語に統一する
- [x] 登録時にパスワードが不適切な場合フィードバックする
- [x] 空欄でサインインしたときのフィードバックを日本語にする

## テスト
tyanio
- [x] toastの文章を柔らかくする
- [x] プレースホルダーを日本語に統一する
- [x] 登録時にパスワードが不適切な場合フィードバックする
- [x] 空欄でサインインしたときのフィードバックを日本語にする

Yamakatsu63
- [x] toastの文章を柔らかくする
- [x] プレースホルダーを日本語に統一する
- [x] 登録時にパスワードが不適切な場合フィードバックする
- [x] 空欄でサインインしたときのフィードバックを日本語にする
