### PR TITLE
チームIDの作成

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:fluttertoast/fluttertoast.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import './register_page.dart';
 import './signin_page.dart';
 
@@ -115,6 +116,22 @@ class _MyHomePageState extends State<MyHomePage> {
               height: 50.0,
               buttonColor: Colors.white,
               child: RaisedButton(
+                  child: const Text('チーム作成'),
+                  shape: OutlineInputBorder(
+                    borderRadius: BorderRadius.all(Radius.circular(10.0)),
+                  ),
+                  onPressed: () async {
+                    _createTeam(); //チームの作成
+                  }),
+            ),
+          ),
+          Container(
+            margin: const EdgeInsets.fromLTRB(100.0, 16.0, 16.0, 0.0),
+            child: ButtonTheme(
+              minWidth: 200.0,
+              height: 50.0,
+              buttonColor: Colors.white,
+              child: RaisedButton(
                   child: const Text('サインアウト'),
                   shape: OutlineInputBorder(
                     borderRadius: BorderRadius.all(Radius.circular(10.0)),
@@ -124,7 +141,7 @@ class _MyHomePageState extends State<MyHomePage> {
                     final String email = user.email;
                     // トーストを表示
                     Fluttertoast.showToast(
-                        msg: email + 'はサインアウトしました．',
+                      msg: email + 'はサインアウトしました．',
                     );
                     setState(() {
                       user = null;
@@ -136,13 +153,50 @@ class _MyHomePageState extends State<MyHomePage> {
             alignment: Alignment.center,
             child: Text(user.email),
           ),
+          Container(
+            alignment: Alignment.center,
+            child: getTeamID()
+          ),
         ],
       );
     }
+  }
+
+  //チームを作成する関数
+  void _createTeam() {
+    Firestore.instance
+        .collection('teams')
+        .document()
+        .setData({'email': user.email});
   }
 
   void _signOut() async {
     await _auth.signOut();
 
   }
+
+  //チームIDを取得する関数
+  Widget getTeamID() {
+
+    return StreamBuilder<QuerySnapshot>(
+
+      //表示したいFiresotreの保存先を指定
+        stream: Firestore.instance
+            .collection("teams")
+            .where("email", isEqualTo: user.email)
+            .snapshots(),
+
+        //streamが更新されるたびに呼ばれる
+        builder: (BuildContext context,
+            AsyncSnapshot<QuerySnapshot> snapshot) {
+
+          //データが取れていない時の処理
+          if (!snapshot.hasData) return const Text('Loading...');
+
+          return Text(snapshot.data.documents[0].documentID);
+
+        }
+    );
+  }
+
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -150,12 +150,13 @@ class _MyHomePageState extends State<MyHomePage> {
             ),
           ),
           Container(
+            padding: const EdgeInsets.all(6),
             alignment: Alignment.center,
             child: Text(user.email),
           ),
           Container(
             alignment: Alignment.center,
-            child: getTeamID()
+            child: getTeamID(),
           ),
         ],
       );
@@ -189,12 +190,23 @@ class _MyHomePageState extends State<MyHomePage> {
         //streamが更新されるたびに呼ばれる
         builder: (BuildContext context,
             AsyncSnapshot<QuerySnapshot> snapshot) {
-
           //データが取れていない時の処理
           if (!snapshot.hasData) return const Text('Loading...');
 
-          return Text(snapshot.data.documents[0].documentID);
-
+//          return Text(snapshot.data.documents[0].documentID);
+            return ListView.builder(
+                  shrinkWrap: true,
+                  itemCount: snapshot.data.documents.length,
+                  itemBuilder: (context, int index) {
+                    return Container(
+                      padding: const EdgeInsets.all(6),
+                      alignment: Alignment.center,
+                      child: Text(
+                        snapshot.data.documents[index].documentID,
+                      ),
+                    );
+                  },
+            );
         }
     );
   }


### PR DESCRIPTION
# バックログアイテムの情報
#15 

作成者：@daigo0907

テスター：@Tyanio @NishidaYujiro 

## タスク
- [x] データベースの構成を決める
- [x] 一意のIDを生成することができる
- [x] 生成した一意のIDをDBに登録できる
- [x] ユーザのデータとチームIDを紐づける
- [x] ユーザのチームIDをDBから取得しアプリ側に表示する

## テスト
@tyanio 
- [x] チーム作成ボタンを押すとfirestoreのteamsの新しいIDの下に自分のメールアドレスが登録されていることをコンソールから確認できる
- [x] ホーム画面に自分のチームIDがすべて表示される

@NishidaYujiro 
- [x] チーム作成ボタンを押すとfirestoreのteamsの新しいIDの下に自分のメールアドレスが登録されていることをコンソールから確認できる
- [x] ホーム画面に自分のチームIDがすべて表示される
