### PR TITLE
main.dartの中身を各ファイルに分割しました

### DIFF
--- a/lib/Screens/Home/home_manager.dart
+++ b/lib/Screens/Home/home_manager.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:the4thdayofmikkabozu/Screens/Home/signout_button.dart';
+import 'package:the4thdayofmikkabozu/Screens/Home/teams_screen.dart';
+
+import 'signin_screen.dart';
+import 'team_create_button.dart';
+
+class HomeManager {
+  final VoidCallback updateStateCallback;
+
+  final FirebaseAuth _auth = FirebaseAuth.instance;
+  FirebaseUser _user = null;
+
+  HomeManager({@required this.updateStateCallback}) : super();
+
+  //ログインの有無によって表示を変える関数
+  Widget showButton() {
+    if (_user == null) {
+      return getSigninScreen();
+    } else {
+      return getHomeScreen();
+    }
+  }
+
+  //SigninScreenを表示する
+  Widget getSigninScreen() {
+    return SigninScreen((FirebaseUser user) {
+      _user = user;
+      updateStateCallback();
+    });
+  }
+
+  //ログインした後の画面を表示する
+  Widget getHomeScreen() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Center(
+          //チーム作成ボタンの表示
+          child: TeamCreateButton(_user.email),
+        ),
+        Center(
+          //サインアウトボタンの表示
+          child: SignoutButton(_auth, _user.email, (FirebaseUser user) {
+            _user = user;
+            updateStateCallback();
+          }),
+        ),
+        Center(
+          //メールアドレスと参加チームIDの表示
+          child: TeamsScreen(_user.email),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/Screens/Home/signin_screen.dart
+++ b/lib/Screens/Home/signin_screen.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import '../../register_page.dart';
+import '../../signin_page.dart';
+
+//コールバック関数を変数として定義
+typedef UserCallback = void Function(FirebaseUser user);
+
+class SigninScreen extends StatelessWidget {
+  final UserCallback callback;
+  //コンストラクタ
+  SigninScreen(this.callback) : super();
+
+  @override
+  Widget build(BuildContext context) {
+    print("start");
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Center(
+          child: Container(
+            margin: const EdgeInsets.fromLTRB(0.0, 16.0, 0.0, 0.0),
+            child: ButtonTheme(
+              minWidth: 200.0,
+              height: 50.0,
+              buttonColor: Colors.white,
+              child: RaisedButton(
+                  child: const Text('登録'),
+                  shape: OutlineInputBorder(
+                    borderRadius: BorderRadius.all(Radius.circular(10.0)),
+                  ),
+                  onPressed: () async {
+                    //移動先のページから値を受け取る
+                    final result = await Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (context) => RegisterPage(),
+                        ));
+                    callback(result);
+                  }),
+            ),
+          ),
+        ),
+        Center(
+          child: Container(
+            margin: const EdgeInsets.fromLTRB(0.0, 16.0, 0.0, 0.0),
+            child: ButtonTheme(
+              minWidth: 200.0,
+              height: 50.0,
+              buttonColor: Colors.white,
+              child: RaisedButton(
+                  child: const Text('サインイン'),
+                  shape: OutlineInputBorder(
+                    borderRadius: BorderRadius.all(Radius.circular(10.0)),
+                  ),
+                  onPressed: () async {
+                    //移動先のページから値を受け取る
+                    final result = await Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (context) => SignInPage(),
+                        ));
+                    callback(result);
+                  }),
+            ),
+          ),
+        ),
+      ],
+    );
+    ;
+  }
+}

--- a/lib/Screens/Home/signout_button.dart
+++ b/lib/Screens/Home/signout_button.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:fluttertoast/fluttertoast.dart';
+
+//コールバック関数を変数として定義
+typedef UserCallback = void Function(FirebaseUser user);
+
+class SignoutButton extends StatelessWidget {
+  FirebaseAuth _auth;
+  String _email;
+  final UserCallback callback;
+
+  SignoutButton(this._auth, this._email, this.callback) : super();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Container(
+        margin: const EdgeInsets.fromLTRB(0.0, 16.0, 0.0, 0.0),
+        child: ButtonTheme(
+          minWidth: 200.0,
+          height: 50.0,
+          buttonColor: Colors.white,
+          child: RaisedButton(
+              child: const Text('サインアウト'),
+              shape: OutlineInputBorder(
+                borderRadius: BorderRadius.all(Radius.circular(10.0)),
+              ),
+              onPressed: () async {
+                signOut();
+                final String email = _email;
+                // トーストを表示
+                Fluttertoast.showToast(
+                  msg: email + 'はサインアウトしました．',
+                );
+//                    setState(() {
+//                      user = null;
+//                    });
+                //ユーザがサインアウトしたことをコールバック
+                callback(null);
+              }),
+        ),
+      ),
+    );
+  }
+
+  //サインアウトをする関数
+  void signOut() async {
+    await _auth.signOut();
+  }
+}

--- a/lib/Screens/Home/team_create_button.dart
+++ b/lib/Screens/Home/team_create_button.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class TeamCreateButton extends StatelessWidget {
+  String _email;
+
+  //コンストラクタ
+  TeamCreateButton(this._email);
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Center(
+          child: Container(
+            margin: const EdgeInsets.fromLTRB(0.0, 16.0, 0.0, 0.0),
+            child: ButtonTheme(
+              minWidth: 200.0,
+              height: 50.0,
+              buttonColor: Colors.white,
+              child: RaisedButton(
+                  child: const Text('チーム作成'),
+                  shape: OutlineInputBorder(
+                    borderRadius: BorderRadius.all(Radius.circular(10.0)),
+                  ),
+                  onPressed: () async {
+                    //チームの作成
+                    createTeam();
+                  }),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  //チームを作成する関数
+  void createTeam() {
+    Firestore.instance
+        .collection('teams')
+        .document()
+        .setData({'email': _email});
+  }
+}

--- a/lib/Screens/Home/teams_screen.dart
+++ b/lib/Screens/Home/teams_screen.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class TeamsScreen extends StatelessWidget {
+  String _email;
+
+  TeamsScreen(this._email);
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Center(
+          child: Container(
+            padding: const EdgeInsets.all(6),
+            alignment: Alignment.center,
+            child: Text(_email),
+          ),
+        ),
+        Center(
+          child: Container(
+            alignment: Alignment.center,
+            child: getTeamID(),
+          ),
+        ),
+      ],
+    );
+  }
+
+  //チームIDを取得する関数
+  Widget getTeamID() {
+    return StreamBuilder<QuerySnapshot>(
+
+        //表示したいFiresotreの保存先を指定
+        stream: Firestore.instance
+            .collection("teams")
+            .where("email", isEqualTo: _email)
+            .snapshots(),
+
+        //streamが更新されるたびに呼ばれる
+        builder: (BuildContext context, AsyncSnapshot<QuerySnapshot> snapshot) {
+          //データが取れていない時の処理
+          if (!snapshot.hasData) return const Text('Loading...');
+
+          return ListView.builder(
+            shrinkWrap: true,
+            itemCount: snapshot.data.documents.length,
+            itemBuilder: (context, int index) {
+              return Container(
+                padding: const EdgeInsets.all(6),
+                alignment: Alignment.center,
+                child: Text(
+                  snapshot.data.documents[index].documentID,
+                ),
+              );
+            },
+          );
+        });
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,10 +6,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:firebase_auth/firebase_auth.dart';
-import 'package:fluttertoast/fluttertoast.dart';
-import 'package:cloud_firestore/cloud_firestore.dart';
-import './register_page.dart';
-import './signin_page.dart';
+import './Screens/Home/home_manager.dart';
 
 final FirebaseAuth _auth = FirebaseAuth.instance;
 
@@ -37,184 +34,29 @@ class MyHomePage extends StatefulWidget {
   final String title;
 
   @override
-  _MyHomePageState createState() => _MyHomePageState();
+  MyHomePageState createState() => MyHomePageState();
 }
 
-class _MyHomePageState extends State<MyHomePage> {
-  FirebaseUser user;
+class MyHomePageState extends State<MyHomePage> {
+  HomeManager _manager;
+
+  @override
+  void initState() {
+    super.initState();
+
+    // マネージャの初期化
+    _manager = HomeManager(updateStateCallback: () {
+      // ステート更新
+      setState(() {});
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
         appBar: AppBar(
           title: Text(widget.title),
         ),
-        body: Container(
-          child: showButton(),
-        ));
-  }
-
-  Widget showButton() {
-    if (user == null) {
-      return Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          Center(
-            child: Container(
-              margin: const EdgeInsets.fromLTRB(0.0, 16.0, 0.0, 0.0),
-              child: ButtonTheme(
-                minWidth: 200.0,
-                height: 50.0,
-                buttonColor: Colors.white,
-                child: RaisedButton(
-                    child: const Text('登録'),
-                    shape: OutlineInputBorder(
-                      borderRadius: BorderRadius.all(Radius.circular(10.0)),
-                    ),
-                    onPressed: () async {
-                      //移動先のページから値を受け取る
-                      final result = await Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                            builder: (context) => RegisterPage(),
-                          ));
-                      user = result;
-                    }),
-              ),
-            ),
-          ),
-          Center(
-            child: Container(
-              margin: const EdgeInsets.fromLTRB(0.0, 16.0, 0.0, 0.0),
-              child: ButtonTheme(
-                minWidth: 200.0,
-                height: 50.0,
-                buttonColor: Colors.white,
-                child: RaisedButton(
-                    child: const Text('サインイン'),
-                    shape: OutlineInputBorder(
-                      borderRadius: BorderRadius.all(Radius.circular(10.0)),
-                    ),
-                    onPressed: () async {
-                      //移動先のページから値を受け取る
-                      final result = await Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                            builder: (context) => SignInPage(),
-                          ));
-                      user = result;
-                    }),
-              ),
-            ),
-          ),
-        ],
-      );
-    } else {
-      return Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          Center(
-            child: Container(
-              margin: const EdgeInsets.fromLTRB(0.0, 16.0, 0.0, 0.0),
-              child: ButtonTheme(
-                minWidth: 200.0,
-                height: 50.0,
-                buttonColor: Colors.white,
-                child: RaisedButton(
-                    child: const Text('チーム作成'),
-                    shape: OutlineInputBorder(
-                      borderRadius: BorderRadius.all(Radius.circular(10.0)),
-                    ),
-                    onPressed: () async {
-                      _createTeam(); //チームの作成
-                    }),
-              ),
-            ),
-          ),
-          Center(
-            child: Container(
-              margin: const EdgeInsets.fromLTRB(0.0, 16.0, 0.0, 0.0),
-              child: ButtonTheme(
-                minWidth: 200.0,
-                height: 50.0,
-                buttonColor: Colors.white,
-                child: RaisedButton(
-                    child: const Text('サインアウト'),
-                    shape: OutlineInputBorder(
-                      borderRadius: BorderRadius.all(Radius.circular(10.0)),
-                    ),
-                    onPressed: () async {
-                      _signOut();
-                      final String email = user.email;
-                      // トーストを表示
-                      Fluttertoast.showToast(
-                        msg: email + 'はサインアウトしました．',
-                      );
-                      setState(() {
-                        user = null;
-                      });
-                    }),
-              ),
-            ),
-          ),
-          Center(
-            child: Container(
-              padding: const EdgeInsets.all(6),
-              alignment: Alignment.center,
-              child: Text(user.email),
-            ),
-          ),
-          Center(
-            child: Container(
-              alignment: Alignment.center,
-              child: getTeamID(),
-            ),
-          ),
-        ],
-      );
-    }
-  }
-
-  //チームを作成する関数
-  void _createTeam() {
-    Firestore.instance
-        .collection('teams')
-        .document()
-        .setData({'email': user.email});
-  }
-
-  void _signOut() async {
-    await _auth.signOut();
-  }
-
-  //チームIDを取得する関数
-  Widget getTeamID() {
-    return StreamBuilder<QuerySnapshot>(
-
-        //表示したいFiresotreの保存先を指定
-        stream: Firestore.instance
-            .collection("teams")
-            .where("email", isEqualTo: user.email)
-            .snapshots(),
-
-        //streamが更新されるたびに呼ばれる
-        builder: (BuildContext context, AsyncSnapshot<QuerySnapshot> snapshot) {
-          //データが取れていない時の処理
-          if (!snapshot.hasData) return const Text('Loading...');
-
-//          return Text(snapshot.data.documents[0].documentID);
-          return ListView.builder(
-            shrinkWrap: true,
-            itemCount: snapshot.data.documents.length,
-            itemBuilder: (context, int index) {
-              return Container(
-                padding: const EdgeInsets.all(6),
-                alignment: Alignment.center,
-                child: Text(
-                  snapshot.data.documents[index].documentID,
-                ),
-              );
-            },
-          );
-        });
+        body: _manager.showButton());
   }
 }


### PR DESCRIPTION
# 概要
main.dartの中身が長くなってきたのでファイルに分割しました。
コードレビューお願いします。
わからないところがあったら聞いてください。

作成者：@Yamakatsu63

テスター：@NishidaYujiro, @daigo0907 

## タスク
- [x] ページ全体を管理するHomeManagerを作成する
- [x] 登録ボタンと、サインインボタンのページを表示するファイルsignin_screen.dartを作成する
- [x] HomeManagerからSigninScreenを呼び出す
- [x] チーム作成ボタンを表示するファイルteam_create_button.dartを作成する
- [x] サインアウトボタンを表示するファイルsigunout_button.dartを作成する
- [x] メールアドレスと参加チームIDを表示するファイルteams_screen.dartを作成する
- [x] HomeManagerから上記の3つのファイルを呼び出す

## テスト
@NishidaYujiro
- [x] ファイル名やメソッド名の命名の確認をする
- [x] コールバックの動作の流れを確認する
- [x] typedefの使い方を確認する
- [x] Dartのコンストラクタの特徴的な使用方法を確認する

@daigo0907
- [x] ファイル名やメソッド名の命名の確認をする
- [x] コールバックの動作の流れを確認する
- [x] typedefの使い方を確認する
- [x] Dartのコンストラクタの特徴的な使用方法を確認する