### PR TITLE
パスワードの可視性を切り替えられるようにしました

### DIFF
--- a/lib/register_page.dart
+++ b/lib/register_page.dart
@@ -21,6 +21,13 @@ class RegisterPageState extends State<RegisterPage> {
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
   final TextEditingController _emailController = TextEditingController();
   final TextEditingController _passwordController = TextEditingController();
+  bool _isHidden = true;
+
+  void _toggleVisibility(){
+    setState(() {
+      _isHidden = !_isHidden;
+    });
+  }
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -44,7 +51,16 @@ class RegisterPageState extends State<RegisterPage> {
             ),
             TextFormField(
               controller: _passwordController,
-              decoration: const InputDecoration(labelText: 'パスワードを入れてね'),
+              decoration: InputDecoration(
+                  labelText: 'パスワードを入れてね',
+                  suffixIcon: _isHidden ? IconButton(
+                    onPressed: _toggleVisibility,
+                    icon: Icon(Icons.visibility),
+                  ) : IconButton(
+                    onPressed: _toggleVisibility,
+                    icon: Icon(Icons.visibility_off),
+                  )
+              ),
               validator: (String value) {
                 if (value.isEmpty) {
                   return 'パスワード入れて（怒）';
@@ -55,7 +71,7 @@ class RegisterPageState extends State<RegisterPage> {
                 }
                 return null;
               },
-              obscureText: true,
+              obscureText: _isHidden,
             ),
             Center(
               child: Container(

--- a/lib/signin_page.dart
+++ b/lib/signin_page.dart
@@ -45,6 +45,13 @@ class _EmailPasswordFormState extends State<_EmailPasswordForm> {
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
   final TextEditingController _emailController = TextEditingController();
   final TextEditingController _passwordController = TextEditingController();
+  bool _isHidden = true;
+
+  void _toggleVisibility(){
+    setState(() {
+      _isHidden = !_isHidden;
+    });
+  }
   @override
   Widget build(BuildContext context) {
     return Form(
@@ -64,14 +71,23 @@ class _EmailPasswordFormState extends State<_EmailPasswordForm> {
           ),
           TextFormField(
             controller: _passwordController,
-            decoration: const InputDecoration(labelText: 'パスワードを入れてね'),
+            decoration: InputDecoration(
+                labelText: 'パスワードを入れてね',
+                suffixIcon: _isHidden ? IconButton(
+                  onPressed: _toggleVisibility,
+                  icon: Icon(Icons.visibility),
+                ) : IconButton(
+                  onPressed: _toggleVisibility,
+                  icon: Icon(Icons.visibility_off),
+                )
+            ),
             validator: (String value) {
               if (value.isEmpty) {
                 return 'パスワード入れて（怒）';
               }
               return null;
             },
-            obscureText: true,
+            obscureText: _isHidden,
           ),
           Center(
             child: Container(


### PR DESCRIPTION
# 概要
登録とサインインをするときのパスワードの表示/非表示を切り替えられるようにしました.

作成者：@NishidaYujiro

テスター：@daigo0907, @kugimasa 

## タスク
- [x] パスワードを入力するフォームにアイコンボタンを追加する
- [x] パスワードの表示を切り替える関数を追加する

## テスト
@daigo0907 
- [ ] 登録画面のパスワード表示を切り替えられるか確認する
- [ ] サインイン画面のパスワード表示を切り替えられるか確認する

@kugimasa 
- [ ] 登録画面のパスワード表示を切り替えられるか確認する
- [ ] サインイン画面のパスワード表示を切り替えられるか確認する