### PR TITLE
走った距離をFireStoreに保存する

### DIFF
--- a/lib/Screens/Home/home_manager.dart
+++ b/lib/Screens/Home/home_manager.dart
@@ -6,6 +6,7 @@ import 'package:the4thdayofmikkabozu/Screens/Home/lookup_team.dart';
 import 'package:the4thdayofmikkabozu/Screens/Home/signout_button.dart';
 import 'package:the4thdayofmikkabozu/Screens/Home/teams_screen.dart';
 import 'package:the4thdayofmikkabozu/Screens/Home/record_form.dart';
+import 'package:the4thdayofmikkabozu/Screens/Home/records_screen.dart';
 
 import 'signin_screen.dart';
 import 'team_create_button.dart';
@@ -67,6 +68,10 @@ class HomeManager {
         Center(
           //走った距離を入力するフォーム
           child: RecordForm(_user.email),
+        ),
+        Center(
+          //距離のデータを表示
+          child: RecordsScreen(_user.email),
         ),
       ],
     );

--- a/lib/Screens/Home/home_manager.dart
+++ b/lib/Screens/Home/home_manager.dart
@@ -66,7 +66,7 @@ class HomeManager {
         ),
         Center(
           //走った距離を入力するフォーム
-          child: RecordForm(),
+          child: RecordForm(_user.email),
         ),
       ],
     );

--- a/lib/Screens/Home/home_manager.dart
+++ b/lib/Screens/Home/home_manager.dart
@@ -5,6 +5,7 @@ import 'package:the4thdayofmikkabozu/Screens/Home/join_button.dart';
 import 'package:the4thdayofmikkabozu/Screens/Home/lookup_team.dart';
 import 'package:the4thdayofmikkabozu/Screens/Home/signout_button.dart';
 import 'package:the4thdayofmikkabozu/Screens/Home/teams_screen.dart';
+import 'package:the4thdayofmikkabozu/Screens/Home/record_form.dart';
 
 import 'signin_screen.dart';
 import 'team_create_button.dart';
@@ -62,6 +63,10 @@ class HomeManager {
         Center(
           //メールアドレスと参加チームIDの表示
           child: TeamsScreen(_user.email),
+        ),
+        Center(
+          //走った距離を入力するフォーム
+          child: RecordForm(),
         ),
       ],
     );

--- a/lib/Screens/Home/record_form.dart
+++ b/lib/Screens/Home/record_form.dart
@@ -50,7 +50,7 @@ class RecordForm extends StatelessWidget {
             .document(userDocId)
             .collection('records')
             .document()
-            .setData({'distance': _recordField.text});
+            .setData({'distance': _recordField.text, 'timestamp': Timestamp.now()});
       } else {
         print("Not Found");
       }

--- a/lib/Screens/Home/record_form.dart
+++ b/lib/Screens/Home/record_form.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:fluttertoast/fluttertoast.dart';
+
+class RecordForm extends StatelessWidget {
+  final TextEditingController _recordField = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: <Widget>[
+        TextFormField(
+          controller: _recordField,
+          decoration: InputDecoration(
+            labelText: '走った距離を入力してください',
+            suffixIcon: IconButton(
+              icon: Icon(Icons.directions_run),
+            ),
+          ),
+          validator: (String value) {
+            if (value.isEmpty) {
+              return '距離が入力されていません';
+            }
+            return null;
+          },
+        ),
+      ],
+    );
+  }
+}

--- a/lib/Screens/Home/record_form.dart
+++ b/lib/Screens/Home/record_form.dart
@@ -4,31 +4,44 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 
 class RecordForm extends StatelessWidget {
   String _email;
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
   final TextEditingController _recordField = TextEditingController();
 
   RecordForm(this._email);
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: <Widget>[
-        TextFormField(
-          controller: _recordField,
-          decoration: InputDecoration(
-            labelText: '走った距離を入力してください',
-            suffixIcon: IconButton(
-              icon: Icon(Icons.directions_run),
-              onPressed: _pushRecord,
+    return Form(
+      key: _formKey,
+        child:Column(
+          children: <Widget>[
+            TextFormField(
+              controller: _recordField,
+              decoration: InputDecoration(
+                labelText: '走った距離を入力してください',
+                suffixIcon: IconButton(
+                  icon: Icon(Icons.directions_run),
+                  onPressed: () async {
+                    if(_formKey.currentState.validate())
+                      _pushRecord();
+                  },
+                ),
+              ),
+              keyboardType: TextInputType.number,
+              //キーボードのエンターを押すとFireStoreに送信
+              onFieldSubmitted: (String value) async {
+                if(_formKey.currentState.validate())
+                  _pushRecord();
+              },
+              validator: (String value) {
+                if (value.isEmpty) {
+                  return '距離が入力されていません';
+                }
+                return null;
+              },
             ),
-          ),
-          validator: (String value) {
-            if (value.isEmpty) {
-              return '距離が入力されていません';
-            }
-            return null;
-          },
+          ],
         ),
-      ],
     );
   }
 

--- a/lib/Screens/Home/record_form.dart
+++ b/lib/Screens/Home/record_form.dart
@@ -1,8 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:fluttertoast/fluttertoast.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 
 class RecordForm extends StatelessWidget {
+  String _email;
   final TextEditingController _recordField = TextEditingController();
+
+  RecordForm(this._email);
 
   @override
   Widget build(BuildContext context) {
@@ -14,6 +18,7 @@ class RecordForm extends StatelessWidget {
             labelText: '走った距離を入力してください',
             suffixIcon: IconButton(
               icon: Icon(Icons.directions_run),
+              onPressed: _pushRecord,
             ),
           ),
           validator: (String value) {
@@ -25,5 +30,30 @@ class RecordForm extends StatelessWidget {
         ),
       ],
     );
+  }
+
+  void _pushRecord() async {
+    //自分のEmailに紐づくドキュメントを取得
+    getData() async {
+      return await Firestore.instance
+          .collection('users')
+          .where("email", isEqualTo: _email)
+          .getDocuments();
+    }
+
+    getData().then((val) {
+      //データの更新
+      if (val.documents.length > 0) {
+        String userDocId = val.documents[0].documentID;
+        Firestore.instance
+            .collection('users')
+            .document(userDocId)
+            .collection('records')
+            .document()
+            .setData({'distance': _recordField.text});
+      } else {
+        print("Not Found");
+      }
+    });
   }
 }

--- a/lib/Screens/Home/records_screen.dart
+++ b/lib/Screens/Home/records_screen.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class RecordsScreen extends StatelessWidget {
+  String _email;
+
+  RecordsScreen(this._email);
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+          child: Container(
+            alignment: Alignment.center,
+            child: getRecords(),
+          ),
+        );
+  }
+
+  //走った距離を取得する関数
+  Widget getRecords() {
+    String userDocId;
+    getData() async {
+      return await Firestore.instance
+          .collection('users')
+          .where('email', isEqualTo: _email)
+          .getDocuments();
+    }
+    getData().then((val) {
+      if (val.documents.length > 0) {
+        userDocId = val.documents[0].documentID;
+        final Stream<QuerySnapshot> stream = Firestore.instance
+          .collection('users')
+          .document(userDocId)
+          .collection('records')
+          .snapshots();
+      }
+    });
+    return StreamBuilder<QuerySnapshot>(
+      //表示したいFiresotreの保存先を指定
+        stream: Firestore.instance
+            .collection('users')
+            .document(userDocId)
+            .collection('records')
+            .snapshots(),
+        //streamが更新されるたびに呼ばれる
+        builder: (BuildContext context, AsyncSnapshot<QuerySnapshot> snapshot) {
+          //データが取れていない時の処理
+          if (!snapshot.hasData) return const Text('Loading...');
+
+          return ListView.builder(
+            shrinkWrap: true,
+            itemCount: snapshot.data.documents.length,
+            itemBuilder: (context, int index) {
+              return Container(
+                padding: const EdgeInsets.all(6),
+                alignment: Alignment.center,
+                child: Text(
+                  snapshot.data.documents[index].documentID,
+                ),
+              );
+            },
+          );
+        });
+  }
+}


### PR DESCRIPTION
# バックログアイテムの情報
#21 

作成者：@kugimasa

テスター：@Yamakatsu63 @daigo0907 

## タスク
- [x] 走った距離を入力するためのTextFormFiledを作成
- [x] データベースの構成に合わせて、FireStoreにデータを送信する
  - [x] 距離(km)のデータを送信する
  - [x] タイムスタンプを送信する
    - [x] タイムスタンプの形式を決める
  -  Ex) `users/自動ID/records/自動ID/timestamp: 2020/06/06/22/00, distance: 3.0`

## テスト
@Yamakatsu63 
- [x] 距離のデータを3つ登録する
- [x] FireStoreでデータを確認する

@daigo0907 
- [ ] 距離のデータを3つ登録する
- [ ] FireStoreでデータを確認する