### PR TITLE
走った距離をFireStoreから取得する

### DIFF
--- a/lib/Screens/Home/home_manager.dart
+++ b/lib/Screens/Home/home_manager.dart
@@ -54,7 +54,7 @@ class HomeManager {
           }),
         ),
         Center(
-            child: LookupTeam(_teamName, (String teamName) {
+            child: LookupTeam(_user.email, _teamName, (String teamName) {
           _teamName = teamName;
           updateStateCallback();
         })),

--- a/lib/Screens/Home/join_button.dart
+++ b/lib/Screens/Home/join_button.dart
@@ -36,7 +36,7 @@ class JoinButton extends StatelessWidget {
         .collection('teams')
         .document(_teamName)
         .collection('users')
-        .document()
+        .document(_email)
         .setData({'email': _email});
 
     //自分の情報にチームの情報を追加
@@ -56,7 +56,7 @@ class JoinButton extends StatelessWidget {
             .collection('users')
             .document(userDocId)
             .collection('teams')
-            .document()
+            .document(_teamName)
             .setData({'team_name': _teamName});
       } else {
         print("Not Found");

--- a/lib/Screens/Home/join_button.dart
+++ b/lib/Screens/Home/join_button.dart
@@ -44,14 +44,13 @@ class JoinButton extends StatelessWidget {
     getData() async {
       return await Firestore.instance
           .collection('users')
-          .where("email", isEqualTo: _email)
-          .getDocuments();
+          .document((_email));
     }
 
     getData().then((val) {
       //データの更新
-      if (val.documents.length > 0) {
-        String userDocId = val.documents[0].documentID;
+      if (val != null) {
+        String userDocId = val.documentID;
         Firestore.instance
             .collection('users')
             .document(userDocId)

--- a/lib/Screens/Home/lookup_team.dart
+++ b/lib/Screens/Home/lookup_team.dart
@@ -36,6 +36,7 @@ class LookupTeam extends StatelessWidget {
     );
   }
 
+  //チームを検索する
   void _lookup_team() async {
     var docs = await Firestore.instance
         .collection("teams")

--- a/lib/Screens/Home/record_form.dart
+++ b/lib/Screens/Home/record_form.dart
@@ -22,8 +22,11 @@ class RecordForm extends StatelessWidget {
                 suffixIcon: IconButton(
                   icon: Icon(Icons.directions_run),
                   onPressed: () async {
-                    if(_formKey.currentState.validate())
+                    if(_formKey.currentState.validate()) {
                       _pushRecord();
+                      //キーボードを閉じる
+                      FocusScope.of(context).requestFocus(new FocusNode());
+                    }
                   },
                 ),
               ),
@@ -67,6 +70,7 @@ class RecordForm extends StatelessWidget {
       } else {
         print("Not Found");
       }
+      _recordField.text = "";
     });
   }
 }

--- a/lib/Screens/Home/records_screen.dart
+++ b/lib/Screens/Home/records_screen.dart
@@ -17,28 +17,11 @@ class RecordsScreen extends StatelessWidget {
 
   //走った距離を取得する関数
   Widget getRecords() {
-    String userDocId;
-    getData() async {
-      return await Firestore.instance
-          .collection('users')
-          .where('email', isEqualTo: _email)
-          .getDocuments();
-    }
-    getData().then((val) {
-      if (val.documents.length > 0) {
-        userDocId = val.documents[0].documentID;
-        final Stream<QuerySnapshot> stream = Firestore.instance
-          .collection('users')
-          .document(userDocId)
-          .collection('records')
-          .snapshots();
-      }
-    });
     return StreamBuilder<QuerySnapshot>(
       //表示したいFiresotreの保存先を指定
         stream: Firestore.instance
             .collection('users')
-            .document(userDocId)
+            .document(_email)
             .collection('records')
             .snapshots(),
         //streamが更新されるたびに呼ばれる
@@ -54,7 +37,7 @@ class RecordsScreen extends StatelessWidget {
                 padding: const EdgeInsets.all(6),
                 alignment: Alignment.center,
                 child: Text(
-                  snapshot.data.documents[index].documentID,
+                  snapshot.data.documents[index]["distance"].toString(),
                 ),
               );
             },

--- a/lib/Screens/Home/records_screen.dart
+++ b/lib/Screens/Home/records_screen.dart
@@ -23,6 +23,7 @@ class RecordsScreen extends StatelessWidget {
             .collection('users')
             .document(_email)
             .collection('records')
+            .orderBy("timestamp",descending: true)
             .snapshots(),
         //streamが更新されるたびに呼ばれる
         builder: (BuildContext context, AsyncSnapshot<QuerySnapshot> snapshot) {

--- a/lib/register_page.dart
+++ b/lib/register_page.dart
@@ -131,7 +131,7 @@ class RegisterPageState extends State<RegisterPage> {
         //Firestoreにemailをpush
         Firestore.instance
             .collection('users')
-            .document()
+            .document(user.email)
             .setData({'email': user.email});
         //前のページに戻る
         Navigator.pop(context, user);

--- a/lib/teamcreate_page.dart
+++ b/lib/teamcreate_page.dart
@@ -83,12 +83,12 @@ class _TeamFormState extends State<_TeamForm> {
                     borderRadius: BorderRadius.all(Radius.circular(10.0)),
                   ),
                   onPressed: () async {
-                    if (_formKey.currentState.validate() && await checkUniqueTeamName(_nameController.text)) {
+                    if (_formKey.currentState.validate() &&
+                        await checkUniqueTeamName(_nameController.text)) {
                       createTeam(_email);
                       updateDataUserData(_email);
                       Navigator.pop(context);
-                    }
-                    else {
+                    } else {
                       Fluttertoast.showToast(
                         msg: 'すでに使われているよ',
                       );
@@ -128,16 +128,13 @@ class _TeamFormState extends State<_TeamForm> {
   void updateDataUserData(String email) {
     //自分のEmailに紐づくドキュメントを取得
     getData() async {
-      return await Firestore.instance
-          .collection('users')
-          .where("email", isEqualTo: _email)
-          .getDocuments();
+      return await Firestore.instance.collection('users').document(_email);
     }
 
     getData().then((val) {
       //データの更新
-      if (val.documents.length > 0) {
-        String userDocId = val.documents[0].documentID;
+      if (val != null) {
+        String userDocId = val.documentID;
         Firestore.instance
             .collection('users')
             .document(userDocId)
@@ -149,17 +146,16 @@ class _TeamFormState extends State<_TeamForm> {
       }
     });
   }
-  
+
   Future<bool> checkUniqueTeamName(String candidateName) async {
     var docs = await Firestore.instance
         .collection("teams")
         .where("team_name", isEqualTo: candidateName)
         .getDocuments();
-    if(docs.documents.length == 0){
+    if (docs.documents.length == 0) {
       return true;
-    }else{
+    } else {
       return false;
     }
-
   }
 }

--- a/lib/teamcreate_page.dart
+++ b/lib/teamcreate_page.dart
@@ -120,7 +120,7 @@ class _TeamFormState extends State<_TeamForm> {
         .collection('teams')
         .document(_nameController.text)
         .collection('users')
-        .document()
+        .document(email)
         .setData({'email': email});
   }
 
@@ -142,7 +142,7 @@ class _TeamFormState extends State<_TeamForm> {
             .collection('users')
             .document(userDocId)
             .collection('teams')
-            .document()
+            .document(_nameController.text)
             .setData({'team_name': _nameController.text});
       } else {
         print("Not Found");


### PR DESCRIPTION
# バックログアイテムの情報
#21 

作成者：@Yamakatsu63

テスター：@IHiromu, @TakedaHiroki 

## タスク
- [x] UsersテーブルのDocmentIDを自動生成されたものからemailに変更する

- [x] Teamsテーブルのユーザに紐づくDocmentIDを自動生成されたものからemailに変更する

- [x] Usersテーブルのチームに紐づくDocumentIDを自動生成されたものからチーム名に変更する

- [x] FireStoreから自分のrecords内のデータを取得する

- [x] 取得したrecordsのデータを一覧表示する

- [x]  入力されたチームのUsersに自分のアドレスがあるか調べる

- [x] 自分のアドレスがあれば、参加できないようにする 

## テスト
@IHiromu
- [x] 新しく自分のアカウントを登録する

- [x] チームを作成する

- [x] 既存のチームに参加する

- [x] 上の３つができていることをdatabase上で確認する

- [x] 走った距離の入力フォームから３つ登録する

- [x] 表示されていることを確認する

- [x] 作成したチームを検索し、参加できないことを確認する

@TakedaHiroki 

- [x] 新しく自分のアカウントを登録する

- [x] チームを作成する

- [x] 既存のチームに参加する

- [x] 上の３つができていることをdatabase上で確認する

- [x] 走った距離の入力フォームから３つ登録する

- [x] 表示されていることを確認する

- [x] 作成したチームを検索し、参加できないことを確認する
