### PR TITLE
Hotfix #65#71#73

### DIFF
--- a/lib/Screens/Home/home_manager.dart
+++ b/lib/Screens/Home/home_manager.dart
@@ -39,41 +39,47 @@ class HomeManager {
 
   //ログインした後の画面を表示する
   Widget getHomeScreen() {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: <Widget>[
-        Center(
-          //チーム作成ボタンの表示
-          child: TeamCreateButton(_user.email),
+    return SingleChildScrollView(
+      child: Center(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Center(
+              //チーム作成ボタンの表示
+              child: TeamCreateButton(_user.email),
+            ),
+            Center(
+              //サインアウトボタンの表示
+              child: SignoutButton(_auth, _user.email, (FirebaseUser user) {
+                _user = user;
+                updateStateCallback();
+              }),
+            ),
+            Center(
+                child: LookupTeam(_user.email, _teamName, (String teamName) {
+              _teamName = teamName;
+              updateStateCallback();
+            })),
+            Center(
+              child: showJoinButton(),
+            ),
+            Center(
+              //メールアドレスと参加チームIDの表示
+              child: TeamsScreen(_user.email),
+            ),
+            Center(
+              //走った距離を入力するフォーム
+              child: RecordForm(_user.email),
+            ),
+            Container(
+              child: Center(
+                //距離のデータを表示
+                child: RecordsScreen(_user.email),
+              ),
+            ),
+          ],
         ),
-        Center(
-          //サインアウトボタンの表示
-          child: SignoutButton(_auth, _user.email, (FirebaseUser user) {
-            _user = user;
-            updateStateCallback();
-          }),
-        ),
-        Center(
-            child: LookupTeam(_user.email, _teamName, (String teamName) {
-          _teamName = teamName;
-          updateStateCallback();
-        })),
-        Center(
-          child: showJoinButton(),
-        ),
-        Center(
-          //メールアドレスと参加チームIDの表示
-          child: TeamsScreen(_user.email),
-        ),
-        Center(
-          //走った距離を入力するフォーム
-          child: RecordForm(_user.email),
-        ),
-        Center(
-          //距離のデータを表示
-          child: RecordsScreen(_user.email),
-        ),
-      ],
+      ),
     );
   }
 

--- a/lib/Screens/Home/lookup_team.dart
+++ b/lib/Screens/Home/lookup_team.dart
@@ -6,6 +6,7 @@ typedef TeamFoundCallback = void Function(String teamName);
 
 class LookupTeam extends StatelessWidget {
   final TeamFoundCallback callback;
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
   final TextEditingController _teamNameField = TextEditingController();
   String _email;
   String _teamname;
@@ -14,31 +15,46 @@ class LookupTeam extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: <Widget>[
-        TextFormField(
-          controller: _teamNameField,
-          decoration: InputDecoration(
-            labelText: '参加したいチーム名を入力してください',
-            suffixIcon: IconButton(
-              icon: Icon(Icons.search),
-              onPressed: _lookup_team,
+    return Form(
+      key: _formKey,
+      child: Column(
+        children: <Widget>[
+          TextFormField(
+            controller: _teamNameField,
+            decoration: InputDecoration(
+              labelText: '参加したいチーム名を入力してください',
+              suffixIcon: IconButton(
+                icon: Icon(Icons.search),
+                onPressed: () async {
+                  if(_formKey.currentState.validate()) {
+                    _lookupTeam();
+                  }
+                  //キーボードを閉じる
+                  FocusScope.of(context).requestFocus(new FocusNode());
+                },
+              ),
+              hintText: _teamname,
             ),
-            hintText: _teamname,
+            //エンターアイコンを変更
+            textInputAction: TextInputAction.search,
+            onFieldSubmitted: (String value) async {
+              if(_formKey.currentState.validate())
+                _lookupTeam();
+            },
+            validator: (String value) {
+              if (value.isEmpty) {
+                return 'チーム名を入力してください';
+              }
+              return null;
+            },
           ),
-          validator: (String value) {
-            if (value.isEmpty) {
-              return 'チーム名を入力してください';
-            }
-            return null;
-          },
-        ),
-      ],
+        ],
+      ),
     );
   }
 
   //チームを検索する
-  void _lookup_team() async {
+  void _lookupTeam() async {
     var docs = await Firestore.instance
         .collection("teams")
         .where("team_name", isEqualTo: _teamNameField.text)

--- a/lib/Screens/Home/record_form.dart
+++ b/lib/Screens/Home/record_form.dart
@@ -24,9 +24,9 @@ class RecordForm extends StatelessWidget {
                   onPressed: () async {
                     if(_formKey.currentState.validate()) {
                       _pushRecord();
-                      //キーボードを閉じる
-                      FocusScope.of(context).requestFocus(new FocusNode());
                     }
+                    //キーボードを閉じる
+                    FocusScope.of(context).requestFocus(new FocusNode());
                   },
                 ),
               ),

--- a/lib/Screens/Home/record_form.dart
+++ b/lib/Screens/Home/record_form.dart
@@ -66,7 +66,7 @@ class RecordForm extends StatelessWidget {
             .document(userDocId)
             .collection('records')
             .document()
-            .setData({'distance': _recordField.text, 'timestamp': Timestamp.now()});
+            .setData({'distance': double.parse(_recordField.text), 'timestamp': Timestamp.now()});
       } else {
         print("Not Found");
       }

--- a/lib/Screens/Home/records_screen.dart
+++ b/lib/Screens/Home/records_screen.dart
@@ -7,12 +7,18 @@ class RecordsScreen extends StatelessWidget {
   RecordsScreen(this._email);
   @override
   Widget build(BuildContext context) {
-    return Center(
-          child: Container(
-            alignment: Alignment.center,
-            child: getRecords(),
+    //画面サイズを取得
+    final Size size = MediaQuery.of(context).size;
+    return ConstrainedBox(
+      //表示できる最大範囲を画面の縦3分の1に指定
+      constraints: BoxConstraints(maxHeight: size.height/3),
+      child: Center(
+            child: Container(
+              alignment: Alignment.center,
+              child: getRecords(),
+            ),
           ),
-        );
+    );
   }
 
   //走った距離を取得する関数

--- a/lib/teamcreate_page.dart
+++ b/lib/teamcreate_page.dart
@@ -83,15 +83,16 @@ class _TeamFormState extends State<_TeamForm> {
                     borderRadius: BorderRadius.all(Radius.circular(10.0)),
                   ),
                   onPressed: () async {
-                    if (_formKey.currentState.validate() &&
-                        await checkUniqueTeamName(_nameController.text)) {
-                      createTeam(_email);
-                      updateDataUserData(_email);
-                      Navigator.pop(context);
-                    } else {
-                      Fluttertoast.showToast(
-                        msg: 'すでに使用されています',
-                      );
+                    if(_formKey.currentState.validate()){
+                      if (await checkUniqueTeamName(_nameController.text)) {
+                        createTeam(_email);
+                        updateDataUserData(_email);
+                        Navigator.pop(context);
+                      } else {
+                        Fluttertoast.showToast(
+                          msg: 'すでに使用されています',
+                        );
+                      }
                     }
                   },
                 ),


### PR DESCRIPTION
# バックログアイテムの情報
#65 , #71 , #73 

作成者：@Yamakatsu63

テスター：@kugimasa, @daigo0907 

## タスク
#65 

- [x] 空欄のままチーム作成ボタンが押されたときの例外処理を追加する

- [x] チーム検索でEnterを押しても検索できるようにする

#71 
- [x] 走った距離をデータベースにプッシュする前にdouble型にパースする

#73 

- [x] 走った距離を表示するウィジェットの範囲を設定する

- [x] 画面のオーバーフローが出ないように設定する

## テスト
@kugimasa 
- [x] 空欄のままチーム作成ボタンを押して例外処理がされるか確認する

- [x] チーム検索でEnterを押しても検索できるか確認する

- [x] 走った距離を追加して、Number型になっているかFirebaseのコンソールから確認する

- [x] 走った距離を9つ以上追加して、画面内に収まっているか確認する

- [x] キーボードを立ち上げて画面オーバーフローのcoutionが出ないか確認する

@daigo0907

- [x] 空欄のままチーム作成ボタンを押して例外処理がされるか確認する

- [x] チーム検索でEnterを押しても検索できるか確認する

- [x] 走った距離を追加して、Number型になっているかFirebaseのコンソールから確認する

- [x] 走った距離を9つ以上追加して、画面内に収まっているか確認する

- [x] キーボードを立ち上げて画面オーバーフローのcoutionが出ないか確認する