### PR TITLE
スライドメニューからチームページに飛べる

### DIFF
--- a/lib/Pages/MyPage/SideMenu/sidemenu.dart
+++ b/lib/Pages/MyPage/SideMenu/sidemenu.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 
 import '../../LookupTeamPage/lookup_team_page.dart';
 import '../../TeamcreatePage/team_create_page.dart';
+import '../../TeamPage/team_page.dart';
 
 class Sidemenu extends StatelessWidget {
   String _email;
@@ -25,41 +26,38 @@ class Sidemenu extends StatelessWidget {
                 image: DecorationImage(
                     fit: BoxFit.fill, image: AssetImage('images/bouzu.png'))),
           ),
-          Container(
-            height: 34,
-            child: ListTile(
-              title: Text('MYPAGE'),
-              onTap: () => {},
-            ),
+          ListTile(
+            dense: true,
+            title: Text('MYPAGE'),
+            onTap: () => {},
           ),
-          Container(
-            height: 34,
-            child: ListTile(
-              title: Text('TEAM',
-              ),
-              trailing: Wrap(spacing: -16, children: <Widget>[
-                IconButton(
-                    icon: Icon(Icons.search),
-                    onPressed: () async {
-                      //チーム作成ページに移動
-                      final result = await Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                            builder: (context) => LookupTeamPage(_email),
-                          ));
-                    }),
-                IconButton(
-                    icon: Icon(Icons.add),
-                    onPressed: () async {
-                      //チーム作成ページに移動
-                      final result = await Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                            builder: (context) => TeamCreatePage(_email),
-                          ));
-                    }),
-              ]),
+          ListTile(
+            dense: true,
+            title: Text(
+              'TEAM',
             ),
+            trailing: Wrap(spacing: -16, children: <Widget>[
+              IconButton(
+                  icon: Icon(Icons.search),
+                  onPressed: () async {
+                    //チーム作成ページに移動
+                    final result = await Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (context) => LookupTeamPage(_email),
+                        ));
+                  }),
+              IconButton(
+                  icon: Icon(Icons.add),
+                  onPressed: () async {
+                    //チーム作成ページに移動
+                    final result = await Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (context) => TeamCreatePage(_email),
+                        ));
+                  }),
+            ]),
           ),
           Container(
             child: StreamBuilder<QuerySnapshot>(
@@ -95,7 +93,17 @@ class Sidemenu extends StatelessWidget {
         children: <Widget>[
           Container(
             height: 34,
-            child: ListTile(title: Text(document['team_name'])),
+            child: ListTile(
+              dense: true,
+              title: Text(document['team_name']),
+              onTap: () => {
+                Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => TeamPage(document['team_name']),
+                    )),
+              },
+            ),
           )
         ],
       ),

--- a/lib/Pages/MyPage/SideMenu/sidemenu.dart
+++ b/lib/Pages/MyPage/SideMenu/sidemenu.dart
@@ -1,3 +1,4 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 
 import '../../LookupTeamPage/lookup_team_page.dart';
@@ -11,6 +12,7 @@ class Sidemenu extends StatelessWidget {
   Widget build(BuildContext context) {
     return Drawer(
       child: ListView(
+        shrinkWrap: true,
         padding: EdgeInsets.zero,
         children: <Widget>[
           DrawerHeader(
@@ -23,37 +25,80 @@ class Sidemenu extends StatelessWidget {
                 image: DecorationImage(
                     fit: BoxFit.fill, image: AssetImage('images/bouzu.png'))),
           ),
-          ListTile(
-            title: Text('MYPAGE'),
-            onTap: () => {},
-          ),
-          ListTile(
-            title: Text('TEAM'),
-            trailing: Wrap(
-              spacing: -16,
-              children: <Widget>[
-                IconButton(icon: Icon(Icons.search),
-                onPressed: () async {
-                    //チーム作成ページに移動
-                  final result = await Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                  builder: (context) => LookupTeamPage(_email),
-                  ));
-                  }),
-                  IconButton(icon: Icon(Icons.add),
-                  onPressed: () async {
-                    //チーム作成ページに移動
-                    final result = await Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                    builder: (context) => TeamCreatePage(_email),
-                    ));
-                    }),
-            ]),
+          Container(
+            height: 34,
+            child: ListTile(
+              title: Text('MYPAGE'),
+              onTap: () => {},
             ),
-          ],
-        ),
-      );
+          ),
+          Container(
+            height: 34,
+            child: ListTile(
+              title: Text('TEAM',
+              ),
+              trailing: Wrap(spacing: -16, children: <Widget>[
+                IconButton(
+                    icon: Icon(Icons.search),
+                    onPressed: () async {
+                      //チーム作成ページに移動
+                      final result = await Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => LookupTeamPage(_email),
+                          ));
+                    }),
+                IconButton(
+                    icon: Icon(Icons.add),
+                    onPressed: () async {
+                      //チーム作成ページに移動
+                      final result = await Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => TeamCreatePage(_email),
+                          ));
+                    }),
+              ]),
+            ),
+          ),
+          Container(
+            child: StreamBuilder<QuerySnapshot>(
+                //表示したいFirestoreの保存先を指定
+                stream: Firestore.instance
+                    .collection('users')
+                    .document(_email)
+                    .collection('teams')
+                    .snapshots(),
+                //streamが更新されるたびに呼ばれる
+                builder: (BuildContext context,
+                    AsyncSnapshot<QuerySnapshot> snapshot) {
+                  //データが取れていない時の処理
+                  if (!snapshot.hasData) return const Text('Loading...');
+                  return ListView.builder(
+                      padding: EdgeInsets.zero,
+                      shrinkWrap: true,
+                      itemCount: snapshot.data.documents.length,
+                      itemBuilder: (context, index) => _buildListItem(
+                          context, snapshot.data.documents[index]));
+                }),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildListItem(BuildContext context, DocumentSnapshot document) {
+    return Padding(
+      padding: EdgeInsets.only(left: 20.0),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          Container(
+            height: 34,
+            child: ListTile(title: Text(document['team_name'])),
+          )
+        ],
+      ),
+    );
   }
 }

--- a/lib/Pages/TeamPage/team_page.dart
+++ b/lib/Pages/TeamPage/team_page.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_picker/flutter_picker.dart';
-import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:the4thdayofmikkabozu/Pages/TeamPage/goal_manager.dart';
 
 class TeamPage extends StatefulWidget {


### PR DESCRIPTION
#77

作成者：Takeda

テスター：@tyanio @kugimasa @iHiromu 

## タスク
- [x] サイドメニューにチーム一覧を表示
- [x] 各チームに遷移できる


## テスト
Tyanio
- [x] チームを複数作成する
- [x] サイドメニューにチーム一覧が表示されている
- [x] 各チームに遷移できる

kugimasa
- [x] チームを複数作成する
- [x] サイドメニューにチーム一覧が表示されている
- [x] 各チームに遷移できる

iHiromu
- [x] チームを複数作成する
- [x] サイドメニューにチーム一覧が表示されている
- [x] 各チームに遷移できる