### PR TITLE
 チーム作成時に名前以外にチームの情報を付与できる(デザイン実装)

### DIFF
--- a/lib/Pages/TeamPage/team_details.dart
+++ b/lib/Pages/TeamPage/team_details.dart
@@ -1,0 +1,60 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+class TeamDetails extends StatelessWidget {
+  String _teamName;
+
+  TeamDetails(this._teamName);
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: <Widget>[
+        Row(
+          children: <Widget>[
+            Text(
+              "チーム概要",
+              style: TextStyle(
+                fontWeight: FontWeight.bold,
+                fontSize: 20,
+                color: Theme.of(context).primaryColor,
+              ),
+            ),
+          ],
+        ),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            Expanded(child: _showDetails()),
+            IconButton(
+                icon: Icon(Icons.mode_edit),
+                onPressed: () async {
+                  //todo 概要変更
+                }),
+          ],
+        ),
+      ],
+    );
+  }
+
+  void _setDetails() {
+    //Firebaseのteamsに概要を設定する
+    //todo firebase
+  }
+
+  Widget _showDetails() {
+    //Firestoreから目標を取得して表示
+    return StreamBuilder<DocumentSnapshot>(
+        //表示したいFiresotreの保存先を指定
+//        stream: Firestore.instance
+//            .collection('teams')
+//            .document((_teamName))
+//            .snapshots(),
+        //streamが更新されるたびに呼ばれる
+        builder:
+            (BuildContext context, AsyncSnapshot<DocumentSnapshot> snapshot) {
+      return Text("チーム概要");
+    });
+  }
+}

--- a/lib/Pages/TeamPage/team_page.dart
+++ b/lib/Pages/TeamPage/team_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:the4thdayofmikkabozu/Pages/TeamPage/goal_manager.dart';
 import 'package:the4thdayofmikkabozu/Pages/TeamPage/members_record.dart';
+import 'package:the4thdayofmikkabozu/Pages/TeamPage/team_details.dart';
 
 class TeamPage extends StatefulWidget {
   String _teamName;
@@ -41,6 +42,7 @@ class TeamPageState extends State<TeamPage> {
               ),
               GoalManager(_teamName),
               MembersRecord(_teamName),
+              TeamDetails(_teamName),
             ]),
       ),
     );


### PR DESCRIPTION
# バックログアイテムの情報
#137 
(デザイン実装のみのためIssueはCloseしない)

作成者：@daigo0907, @kugimasa 

テスター：@Yamakatsu63

## タスク
- [ ] チームページにチームの概要を表示する
   - [x] 概要の内容
   - [ ] 概要が編集できるようにしたい
- [ ] チームでヒットしたチームの詳細を表示する
   - [ ] チーム名
   - [ ] 概要
   - [ ] 目標
- [ ] チーム作成時の入力フォーム追加
  - [ ] チーム概要の入力フォーム
  - [ ] 週の目標の入力フォーム


## テスト
- [ ] テスト１
