### PR TITLE
チーム作成時に概要と目標を設定できるようにする

### DIFF
--- a/lib/Pages/LookupTeamPage/lookup_team_page.dart
+++ b/lib/Pages/LookupTeamPage/lookup_team_page.dart
@@ -14,6 +14,7 @@ class LookupTeamPage extends StatefulWidget {
 class LookupTeamPageState extends State<LookupTeamPage> {
   String _email = userData.userEmail;
   bool _showButton = false;
+  String _docmentID = "aaaaaaaa";
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
   final TextEditingController _teamNameField = TextEditingController();
 
@@ -58,6 +59,9 @@ class LookupTeamPageState extends State<LookupTeamPage> {
                       return null;
                     },
                   ),
+                  Container(
+                    child: showOverview(),
+                  ),
                   Center(
                     child: showJoinButton(),
                   ),
@@ -81,6 +85,7 @@ class LookupTeamPageState extends State<LookupTeamPage> {
       if (await _searchAlreadyJoin(docs.documents[0].documentID)) {
         setState(() {
           _showButton = true;
+          _docmentID = docs.documents[0].documentID;
         });
       } else {
         //すでに自分がチームに参加している
@@ -91,6 +96,7 @@ class LookupTeamPageState extends State<LookupTeamPage> {
     } else {
       setState(() {
         _showButton = false;
+        _docmentID = "";
       });
       Fluttertoast.showToast(
         msg: '存在しないチームです',
@@ -111,6 +117,54 @@ class LookupTeamPageState extends State<LookupTeamPage> {
     } else {
       return true;
     }
+  }
+
+  Widget showOverview(){
+    return StreamBuilder<DocumentSnapshot>(
+      //表示したいFiresotreの保存先を指定
+        stream: Firestore.instance
+            .collection('teams')
+            .document((_docmentID))
+            .snapshots(),
+        //streamが更新されるたびに呼ばれる
+        builder:
+            (BuildContext context, AsyncSnapshot<DocumentSnapshot> snapshot) {
+          //データが取れていない時の処理
+          if (!snapshot.hasData) return const Text('Loading...');
+          else if (snapshot.data.exists){
+            if (snapshot.data["team_overview"] != null) {
+              //検索結果の表示
+              return Container(
+                child: Column(
+                  children: [
+                    Text(
+                      "チーム名 " + snapshot.data["team_name"].toString(),
+                      style: TextStyle(
+                        fontSize: 20,
+                      ),
+                    ),
+                    Text(
+                      "概要 " + snapshot.data["team_overview"].toString(),
+                      style: TextStyle(
+                        fontSize: 20,
+                      ),
+                    ),
+                    Text(
+                      "目標 " + snapshot.data["goal"].toString() + "km",
+                      style: TextStyle(
+                        fontSize: 20,
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            }else {
+              return Container();
+            }
+          } else {
+            return Container();
+          }
+        });
   }
 
   Widget showJoinButton() {

--- a/lib/Pages/TeamCreatePage/team_create_page.dart
+++ b/lib/Pages/TeamCreatePage/team_create_page.dart
@@ -14,6 +14,8 @@ class TeamCreatePageState extends State<TeamCreatePage> {
   String _email = userData.userEmail;
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
   final TextEditingController _nameController = TextEditingController();
+  final TextEditingController _overviewController = TextEditingController();
+  final TextEditingController _goalController = TextEditingController();
 
   @override
   Widget build(BuildContext context) {
@@ -39,6 +41,31 @@ class TeamCreatePageState extends State<TeamCreatePage> {
                         return '登録にはチーム名が必要です';
                       } else if (value.length >= 19) {
                         return 'チーム名が長すぎます';
+                      }
+                      return null;
+                    },
+                  ),
+                  TextFormField(
+                    controller: _overviewController,
+                    decoration:
+                    const InputDecoration(labelText: 'チームの概要を入力してください'),
+                    validator: (String value) {
+                      if (value.isEmpty) {
+                        return '登録にはチームの概要が必要です';
+                      }
+                      return null;
+                    },
+                  ),
+                  TextFormField(
+                    controller: _goalController,
+                    keyboardType: TextInputType.number,
+                    decoration:
+                    const InputDecoration(labelText: 'チームの目標を入力してください'),
+                    validator: (String value) {
+                      if (value.isEmpty) {
+                        return '登録にはチームの目標が必要です';
+                      } else if (_goalController.text.contains(',')){
+                        return '目標に","を含めないでください';
                       }
                       return null;
                     },
@@ -93,7 +120,11 @@ class TeamCreatePageState extends State<TeamCreatePage> {
     Firestore.instance
         .collection('teams')
         .document(_nameController.text)
-        .setData(<String, dynamic>{'team_name': _nameController.text});
+        .setData(<String, dynamic>{
+          'team_name': _nameController.text,
+          'goal': int.parse(_goalController.text),
+          'team_overview': _overviewController.text,
+        });
 
     Firestore.instance
         .collection('teams')
@@ -110,7 +141,11 @@ class TeamCreatePageState extends State<TeamCreatePage> {
         .document(_email)
         .collection('teams')
         .document(_nameController.text)
-        .setData(<String, dynamic>{'team_name': _nameController.text});
+        .setData(<String, dynamic>{
+          'team_name': _nameController.text,
+          'goal': int.parse(_goalController.text),
+          'team_overview': _overviewController.text,
+        });
   }
 
   Future<bool> checkUniqueTeamName(String candidateName) async {

--- a/lib/Pages/TeamPage/overview_manager.dart
+++ b/lib/Pages/TeamPage/overview_manager.dart
@@ -23,7 +23,7 @@ class OverviewManager extends StatelessWidget {
       ],
     );
   }
-  
+
   Widget _showOverview() {
     //Firestoreから目標を取得して表示
     return StreamBuilder<DocumentSnapshot>(

--- a/lib/Pages/TeamPage/overview_manager.dart
+++ b/lib/Pages/TeamPage/overview_manager.dart
@@ -1,0 +1,52 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_picker/flutter_picker.dart';
+
+class OverviewManager extends StatelessWidget {
+  String _teamName;
+
+  OverviewManager(this._teamName);
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: <Widget>[
+        Center(child: _showOverview()),
+//        IconButton(
+//            icon: Icon(Icons.mode_edit),
+//            onPressed: () async {
+//              //概要変更
+//              showPickerNumber(context);
+//            }),
+      ],
+    );
+  }
+  
+  Widget _showOverview() {
+    //Firestoreから目標を取得して表示
+    return StreamBuilder<DocumentSnapshot>(
+      //表示したいFiresotreの保存先を指定
+        stream: Firestore.instance
+            .collection('teams')
+            .document((_teamName))
+            .snapshots(),
+        //streamが更新されるたびに呼ばれる
+        builder:
+            (BuildContext context, AsyncSnapshot<DocumentSnapshot> snapshot) {
+          //データが取れていない時の処理
+          if (!snapshot.hasData) return const Text('Loading...');
+          if (snapshot.data["team_overview"] != null) {
+            return Text(
+              snapshot.data["team_overview"].toString(),
+              style: TextStyle(
+                fontSize: 20,
+              ),
+            );
+          } else {
+            return Container();
+          }
+        });
+  }
+}

--- a/lib/Pages/TeamPage/team_page.dart
+++ b/lib/Pages/TeamPage/team_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:the4thdayofmikkabozu/Pages/TeamPage/goal_manager.dart';
+import 'package:the4thdayofmikkabozu/Pages/TeamPage/overview_manager.dart';
 import 'package:the4thdayofmikkabozu/Pages/TeamPage/members_record.dart';
 
 class TeamPage extends StatefulWidget {
@@ -26,6 +27,20 @@ class TeamPageState extends State<TeamPage> {
         child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
+              Center(
+                child: Padding(
+                  padding: EdgeInsets.all(20.0),
+                  child: Text(
+                    '概要',
+                    style: TextStyle(
+                      fontWeight: FontWeight.bold,
+                      fontSize: 20,
+                      color: Theme.of(context).primaryColor,
+                    ),
+                  ),
+                ),
+              ),
+              OverviewManager(_teamName),
               Center(
                 child: Padding(
                   padding: EdgeInsets.all(20.0),


### PR DESCRIPTION
#137 

作成者：@NishidaYujiro

## タスク
- [x] チーム作成時に概要と目標距離の入力欄を作成する
- [x] チーム作成するときにデータベースに情報をプッシュする
- [x]  チームページでチームの概要をデータベースから取得する
- [x]  チームの概要をチームページに表示する
- [x]  チーム検索したときに概要と目標もデータベースから取得する
- [x] 概要と目標も検索結果に表示する

## テスト
- [x] 概要と目標距離の入力してチームが作成できる
- [x]  チームの概要をチームページで見ることができる
- [x] 検索したチームの概要と目標距離を見ることができる

