### PR TITLE
ユーザ名の登録と表示

### DIFF
--- a/lib/Pages/LookupTeamPage/join_button.dart
+++ b/lib/Pages/LookupTeamPage/join_button.dart
@@ -37,7 +37,7 @@ class JoinButton extends StatelessWidget {
         .document(_teamName)
         .collection('users')
         .document(_email)
-        .setData(<String, dynamic>{'email': _email});
+        .setData(<String, dynamic>{'email': _email, 'name': userData.userName});
 
     //自分の情報にチームの情報を追加
     Firestore.instance

--- a/lib/Pages/MemberPage/member_page.dart
+++ b/lib/Pages/MemberPage/member_page.dart
@@ -5,17 +5,20 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter_calendar_carousel/classes/event.dart';
 import 'package:flutter_calendar_carousel/flutter_calendar_carousel.dart';
 import 'package:the4thdayofmikkabozu/hex_color.dart' as hex;
+import 'package:the4thdayofmikkabozu/user_data.dart';
 
 class MemberPage extends StatefulWidget {
   String _email;
+  String _name;
   //コンストラクタ
-  MemberPage(this._email);
+  MemberPage(this._email, this._name);
   @override
-  State<StatefulWidget> createState() => MemberPageState(_email);
+  State<StatefulWidget> createState() => MemberPageState(_email, _name);
 }
 
 class MemberPageState extends State<MemberPage> {
   String _email;
+  String _name;
   DateTime _currentDate = DateTime.now();
   EventList<Event> _markedDateMap = EventList<Event>();
   bool _shouldShowRecord = false;
@@ -32,7 +35,7 @@ class MemberPageState extends State<MemberPage> {
   }
 
   //コンストラクタ
-  MemberPageState(this._email);
+  MemberPageState(this._email, this._name);
 
   @override
   void initState() {
@@ -97,7 +100,7 @@ class MemberPageState extends State<MemberPage> {
     Size size = MediaQuery.of(context).size;
     return Scaffold(
       appBar: AppBar(
-        title: Text(_email),
+        title: Text(_name),
       ),
       body: SingleChildScrollView(
         child: Center(

--- a/lib/Pages/RegisterPage/register_page.dart
+++ b/lib/Pages/RegisterPage/register_page.dart
@@ -19,6 +19,7 @@ class RegisterPageState extends State<RegisterPage> {
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
   final TextEditingController _emailController = TextEditingController();
   final TextEditingController _passwordController = TextEditingController();
+  final TextEditingController _userNameController = TextEditingController();
   bool _isHidden = true;
 
   void _toggleVisibility(){
@@ -37,6 +38,16 @@ class RegisterPageState extends State<RegisterPage> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
+            TextFormField(
+              controller: _userNameController,
+              decoration: const InputDecoration(labelText: 'ユーザー名を入力してください'),
+              validator: (String value) {
+                if (value.isEmpty) {
+                  return 'ユーザー名が入力されていません';
+                }
+                return null;
+              },
+            ),
             TextFormField(
               controller: _emailController,
               decoration: const InputDecoration(labelText: 'アドレスを入力してください'),
@@ -117,6 +128,7 @@ class RegisterPageState extends State<RegisterPage> {
       ))
           .user;
     } on PlatformException catch (e) {
+      print(e);
       //メールアドレスが使われていた場合実行
       if (e.code == "ERROR_EMAIL_ALREADY_IN_USE") {
         // トーストを表示
@@ -127,7 +139,7 @@ class RegisterPageState extends State<RegisterPage> {
     }
 
     if (user != null) {
-      //emailとパスワードを端末に保存
+      //emailとパスワードを端末に保存(自動ログイン用)
       await prefs.setString('email', _emailController.text);
       await prefs.setString('password', _passwordController.text);
       print(prefs.getString('email'));
@@ -138,7 +150,7 @@ class RegisterPageState extends State<RegisterPage> {
         Firestore.instance
             .collection('users')
             .document(user.email)
-            .setData(<String, dynamic>{'email': user.email});
+            .setData(<String, dynamic>{'email': user.email, 'name': _userNameController.text});
       });
       await Navigator.pushAndRemoveUntil<dynamic>(
           context,
@@ -147,6 +159,8 @@ class RegisterPageState extends State<RegisterPage> {
           ),
           (_) => false
       );
+    } else{
+      print("can't register");
     }
   }
 

--- a/lib/Pages/TeamMainPage/team_main_page.dart
+++ b/lib/Pages/TeamMainPage/team_main_page.dart
@@ -46,28 +46,30 @@ class TeamMainPageState extends State<TeamMainPage> {
           ),
         ],
       ),
-      body: Column(
-        children: <Widget>[
-          Container(
-            height: size.height * (6 / 12),
-            child: StreamBuilder<QuerySnapshot>(
-                //表示したいFirestoreの保存先を指定
-                stream: Firestore.instance.collection('users').document(_email).collection('teams').snapshots(),
-                //streamが更新されるたびに呼ばれる
-                builder: (BuildContext context, AsyncSnapshot<QuerySnapshot> snapshot) {
-                  //データが取れていない時の処理
-                  if (!snapshot.hasData) return const Text('Loading...');
-                  return Scrollbar(
-                    child: ListView.builder(
-                        padding: EdgeInsets.zero,
-                        shrinkWrap: true,
-                        itemCount: snapshot.data.documents.length,
-                        itemBuilder: (context, index) =>
-                            _buildListItem(context, snapshot.data.documents[index]['team_name'] as String)),
-                  );
-                }),
-          ),
-        ],
+      body: SingleChildScrollView(
+        child: Column(
+          children: <Widget>[
+            Container(
+              height: size.height * (3 / 4),
+              child: StreamBuilder<QuerySnapshot>(
+                  //表示したいFirestoreの保存先を指定
+                  stream: Firestore.instance.collection('users').document(_email).collection('teams').snapshots(),
+                  //streamが更新されるたびに呼ばれる
+                  builder: (BuildContext context, AsyncSnapshot<QuerySnapshot> snapshot) {
+                    //データが取れていない時の処理
+                    if (!snapshot.hasData) return const Text('Loading...');
+                    return Scrollbar(
+                      child: ListView.builder(
+                          padding: EdgeInsets.zero,
+                          shrinkWrap: true,
+                          itemCount: snapshot.data.documents.length,
+                          itemBuilder: (context, index) =>
+                              _buildListItem(context, snapshot.data.documents[index]['team_name'] as String)),
+                    );
+                  }),
+            ),
+          ],
+        ),
       ),
       drawer: Sidemenu(),
     );

--- a/lib/Pages/TeamPage/members_record.dart
+++ b/lib/Pages/TeamPage/members_record.dart
@@ -107,6 +107,10 @@ class MembersRecord extends StatelessWidget {
                                 itemBuilder: (context, int index) {
                                   String userEmail =
                                       snapshot.data.documents[index].documentID.toString();
+                                  String userName = "Guest";
+                                  if(snapshot.data.documents[index].data['name'] != null) {
+                                    userName =snapshot.data.documents[index].data['name'].toString();
+                                  }
                                   if(memberSnapshot.data[userEmail] as bool){
                                     return ListTile(
                                       leading: Icon(
@@ -118,13 +122,11 @@ class MembersRecord extends StatelessWidget {
                                         height: 30.0,
                                         width: 30.0,
                                       ),
-                                      title: Text(userEmail),
+                                      title: Text(userName),
                                       onTap: () => Navigator.push<dynamic>(
                                           context,
                                           MaterialPageRoute<dynamic>(
-                                            builder: (context) => MemberPage(snapshot
-                                                .data.documents[index].documentID
-                                                .toString()),
+                                            builder: (context) => MemberPage(userEmail, userName),
                                           )),
                                     );
                                   } else{
@@ -133,13 +135,11 @@ class MembersRecord extends StatelessWidget {
                                         Icons.account_circle,
                                         size: 50,
                                       ),
-                                      title: Text(userEmail),
+                                      title: Text(userName),
                                       onTap: () => Navigator.push<dynamic>(
                                           context,
                                           MaterialPageRoute<dynamic>(
-                                            builder: (context) => MemberPage(snapshot
-                                                .data.documents[index].documentID
-                                                .toString()),
+                                            builder: (context) => MemberPage(userEmail, userName),
                                           )),
                                     );
                                   }

--- a/lib/Pages/TeamPage/members_record.dart
+++ b/lib/Pages/TeamPage/members_record.dart
@@ -47,7 +47,7 @@ class MembersRecord extends StatelessWidget {
                       print(memberSnapshot.data);
                       int achievedMemberNum = 0;
                       memberSnapshot.data.forEach((dynamic key, dynamic value) {
-                        if(value as bool){
+                        if(value[0] as bool){
                           achievementNum++;
                         }
                       });
@@ -108,10 +108,11 @@ class MembersRecord extends StatelessWidget {
                                   String userEmail =
                                       snapshot.data.documents[index].documentID.toString();
                                   String userName = "Guest";
-                                  if(snapshot.data.documents[index].data['name'] != null) {
-                                    userName =snapshot.data.documents[index].data['name'].toString();
+                                  print(memberSnapshot.data[userEmail][1]);
+                                  if(memberSnapshot.data[userEmail][1] != "null") {
+                                    userName = memberSnapshot.data[userEmail][1] as String;
                                   }
-                                  if(memberSnapshot.data[userEmail] as bool){
+                                  if(memberSnapshot.data[userEmail][0] as bool){
                                     return ListTile(
                                       leading: Icon(
                                         Icons.account_circle,
@@ -171,26 +172,33 @@ class MembersRecord extends StatelessWidget {
 
   Future<Map> getMemberRecord(QuerySnapshot data, int goal) async{
     // マップの初期化
-    Map<String, bool> hasMemberAchieved = {};
+    Map<String, List> userMap = {};
     for(int i=0; i<data.documents.length; i++){
+      List<dynamic> hasMemberAchieved = List<dynamic>();
       double totalDistance = 0.0;
-      QuerySnapshot snapshots = await Firestore.instance
+      QuerySnapshot recordSnapshots = await Firestore.instance
           .collection('users')
           .document(data.documents[i].documentID)
           .collection('records')
           .where("timestamp", isGreaterThanOrEqualTo: Timestamp.fromDate(getLastSundayDataTime()))
           .getDocuments();
-      for(int j=0; j<snapshots.documents.length; j++){
-        totalDistance += snapshots.documents[j].data['distance'] as double;
+      DocumentSnapshot userSnapshot = await Firestore.instance
+          .collection('users')
+          .document(data.documents[i].documentID)
+          .get();
+      for(int j=0; j<recordSnapshots.documents.length; j++){
+        totalDistance += recordSnapshots.documents[j].data['distance'] as double;
       }
       // 目標を達成しているかの確認
       if(((totalDistance / 100.0).round() / 10) >= goal){
-        hasMemberAchieved[data.documents[i].documentID] = true;
+        hasMemberAchieved.add(true);
       } else{
-        hasMemberAchieved[data.documents[i].documentID] = false;
+        hasMemberAchieved.add(false);
       }
+      hasMemberAchieved.add(userSnapshot.data['name'].toString());//0にbool,1にname
+      userMap[data.documents[i].documentID] = hasMemberAchieved;
     }
-    return hasMemberAchieved;
+    return userMap;
   }
 
   // 直近の日曜日の日付を算出し、その日付を返す

--- a/lib/SideMenu/sidemenu.dart
+++ b/lib/SideMenu/sidemenu.dart
@@ -19,7 +19,10 @@ class Sidemenu extends StatelessWidget {
           ),
           Row(
             children: [
-              Center(child: Container(child: Text(userData.userEmail))),
+              Expanded(
+                child: Container(),
+              ),
+              Container(child: Text(userData.userEmail)),
               IconButton(
                 icon: const Icon(Icons.edit),
                 color: Colors.grey,
@@ -28,28 +31,39 @@ class Sidemenu extends StatelessWidget {
                     context: context,
                     builder: (context) {
                       return SimpleDialog(
-                        title: Text("タイトル"),
+                        title: Text("ユーザ名変更"),
                         children: [
-                          TextField(
-                            obscureText: true,
-                            decoration: InputDecoration(
-                              border: OutlineInputBorder(),
-                              labelText: '変更するユーザー名を入力してください',
+                          Padding(
+                            padding:
+                                const EdgeInsets.only(left: 8.0, right: 8.0),
+                            child: TextField(
+                              decoration: InputDecoration(
+                                border: OutlineInputBorder(),
+                                labelText: '変更するユーザ名を入力してください',
+                              ),
                             ),
                           ),
-                          FlatButton(
-                            child: Text("キャンセル"),
-                            onPressed: () => Navigator.pop(context),
-                          ),
-                          FlatButton(
-                            child: Text("変更"),
-                            onPressed: () => Navigator.pop(context),
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.end,
+                            children: <Widget>[
+                              FlatButton(
+                                child: Text("キャンセル"),
+                                onPressed: () => Navigator.pop(context),
+                              ),
+                              FlatButton(
+                                child: Text("変更"),
+                                onPressed: () => Navigator.pop(context),
+                              ),
+                            ],
                           ),
                         ],
                       );
                     },
                   );
                 },
+              ),
+              Expanded(
+                child: Container(),
               ),
             ],
           ),

--- a/lib/SideMenu/sidemenu.dart
+++ b/lib/SideMenu/sidemenu.dart
@@ -1,8 +1,16 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:the4thdayofmikkabozu/SideMenu/signout_button.dart';
 import 'package:the4thdayofmikkabozu/user_data.dart' as userData;
 
-class Sidemenu extends StatelessWidget {
+class Sidemenu extends StatefulWidget{
+  @override
+  State<StatefulWidget> createState() => SidemenuState();
+}
+
+class SidemenuState extends State<Sidemenu> {
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+  final TextEditingController _userNameController = TextEditingController();
   @override
   Widget build(BuildContext context) {
     return Drawer(
@@ -22,7 +30,7 @@ class Sidemenu extends StatelessWidget {
               Expanded(
                 child: Container(),
               ),
-              Container(child: Text(userData.userEmail)),
+              Container(child: Text(userData.userName)),
               IconButton(
                 icon: const Icon(Icons.edit),
                 color: Colors.grey,
@@ -30,33 +38,58 @@ class Sidemenu extends StatelessWidget {
                   showDialog<dynamic>(
                     context: context,
                     builder: (context) {
-                      return SimpleDialog(
-                        title: Text("ユーザ名変更"),
-                        children: [
-                          Padding(
-                            padding:
-                                const EdgeInsets.only(left: 8.0, right: 8.0),
-                            child: TextField(
-                              decoration: InputDecoration(
-                                border: OutlineInputBorder(),
-                                labelText: '変更するユーザ名を入力してください',
+                      return Form(
+                        key: _formKey,
+                        child: SimpleDialog(
+                          title: Text("ユーザ名変更"),
+                          children: [
+                            Padding(
+                              padding:
+                                  const EdgeInsets.only(left: 8.0, right: 8.0),
+                              child: TextFormField(
+                                controller: _userNameController,
+                                decoration: InputDecoration(
+                                  border: OutlineInputBorder(),
+                                  labelText: '変更するユーザ名を入力してください',
+                                ),
+                                validator: (String value) {
+                                  if (value.isEmpty) {
+                                    return 'ユーザ名が入力されていません';
+                                  }
+                                  return null;
+                                },
                               ),
                             ),
-                          ),
-                          Row(
-                            mainAxisAlignment: MainAxisAlignment.end,
-                            children: <Widget>[
-                              FlatButton(
-                                child: Text("キャンセル"),
-                                onPressed: () => Navigator.pop(context),
-                              ),
-                              FlatButton(
-                                child: Text("変更"),
-                                onPressed: () => Navigator.pop(context),
-                              ),
-                            ],
-                          ),
-                        ],
+                            Row(
+                              mainAxisAlignment: MainAxisAlignment.end,
+                              children: <Widget>[
+                                FlatButton(
+                                  child: Text("キャンセル"),
+                                  onPressed: () => Navigator.pop(context),
+                                ),
+                                FlatButton(
+                                  child: Text("変更"),
+                                  onPressed: () {
+                                    if (_formKey.currentState.validate()) {
+                                      Firestore.instance
+                                          .collection('users')
+                                          .document(userData.userEmail)
+                                          .setData(<String, dynamic>{
+                                        'name': _userNameController.text
+                                      });
+                                      userData.userName = _userNameController.text;
+                                      _userNameController.text = "";
+                                      setState(() {
+
+                                      });
+                                      Navigator.pop(context);
+                                    }
+                                  }
+                                ),
+                              ],
+                            ),
+                          ],
+                        ),
                       );
                     },
                   );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'package:the4thdayofmikkabozu/user_data.dart' as userData;
 import 'package:the4thdayofmikkabozu/permission.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
@@ -78,6 +79,17 @@ class MyHomePageState extends State<MyHomePage> {
         password: prefs.getString('password'),
       ))
           .user;
+
+      var snapshot = await Firestore.instance
+          .collection('users')
+          .document(_user.email)
+          .get();
+
+      String userName = "Guest";
+      if(snapshot.data['name'] != null){
+        userName = snapshot.data['name'].toString();
+      }
+      userData.userName = userName;
       userData.userEmail = _user.email;
       userData.firebaseUser = _user;
       return true;

--- a/lib/user_data.dart
+++ b/lib/user_data.dart
@@ -1,4 +1,5 @@
 import 'package:firebase_auth/firebase_auth.dart';
 // グローバル変数
 String userEmail;
+String userName;
 FirebaseUser firebaseUser;


### PR DESCRIPTION
# バックログアイテムの情報
#31 

作成者：@Yamakatsu63, @NishidaYujiro 

テスター：@tyanio

## タスク
- [x] 登録ページにユーザー名を記入する欄を追加する
- [x] ユーザー名をデータベースのフィールドに追加する
- [x] サイドバーのメールアドレスをユーザー名に変更する
- [x] チームページでメールアドレスを表示しているところをユーザー名に変更する

## テスト
- [x] 登録画面からユーザ名が登録できる
- [x] サイドバーにユーザ名が表示されている
- [x] チームページでメンバーのユーザ名が表示される
