### PR TITLE
チーム検索結果をカードで表示する

### DIFF
--- a/lib/Pages/LookupTeamPage/join_button.dart
+++ b/lib/Pages/LookupTeamPage/join_button.dart
@@ -30,7 +30,7 @@ class JoinButton extends StatelessWidget {
     );
   }
 
-  void _joinTeam() {
+  void _joinTeam() async {
     //teamに自分の情報を追加
     Firestore.instance
         .collection('teams')
@@ -46,5 +46,18 @@ class JoinButton extends StatelessWidget {
         .collection('teams')
         .document(_teamName)
         .setData(<String, dynamic>{'team_name': _teamName});
+    
+    // チームの参加人数を取得
+    DocumentSnapshot snapshot = await Firestore.instance
+        .collection('teams')
+        .document(_teamName)
+        .get();
+    
+    // チームの参加人数を1増やしてプッシュ
+    int userNum = (snapshot.data['user_num'] as int) + 1;
+    Firestore.instance
+      .collection('teams')
+      .document(_teamName)
+      .updateData(<String, num>{'user_num': userNum});
   }
 }

--- a/lib/Pages/LookupTeamPage/join_button.dart
+++ b/lib/Pages/LookupTeamPage/join_button.dart
@@ -11,22 +11,15 @@ class JoinButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Center(
-      child: ButtonTheme(
-        minWidth: 200.0,
-        height: 50.0,
-        buttonColor: Colors.white,
-        child: RaisedButton(
-            child: const Text('参加'),
-            shape: OutlineInputBorder(
-              borderRadius: BorderRadius.all(Radius.circular(10.0)),
-            ),
-            onPressed: () async {
-              //チームに参加
-              _joinTeam();
-              //前のページに戻る
-              Navigator.pop(context);
-            }),
-      ),
+      child: FlatButton(
+          child: const Text('参加'),
+          textColor: Theme.of(context).primaryColor,
+          onPressed: () async {
+            //チームに参加
+            _joinTeam();
+            //前のページに戻る
+            Navigator.pop(context);
+          }),
     );
   }
 

--- a/lib/Pages/LookupTeamPage/lookup_team_page.dart
+++ b/lib/Pages/LookupTeamPage/lookup_team_page.dart
@@ -1,9 +1,7 @@
-import 'package:flutter/material.dart';
-import 'package:fluttertoast/fluttertoast.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:the4thdayofmikkabozu/user_data.dart' as userData;
+import 'package:flutter/material.dart';
 import 'package:the4thdayofmikkabozu/Pages/LookupTeamPage/team_card.dart';
-import 'package:the4thdayofmikkabozu/Pages/LookupTeamPage/join_button.dart';
+import 'package:the4thdayofmikkabozu/user_data.dart' as userData;
 
 class LookupTeamPage extends StatefulWidget {
   final String title = 'チーム検索';
@@ -53,14 +51,16 @@ class LookupTeamPageState extends State<LookupTeamPage> {
                               setState(() {});
                             }
                             //キーボードを閉じる
-                            FocusScope.of(context).requestFocus(new FocusNode());
+                            FocusScope.of(context)
+                                .requestFocus(new FocusNode());
                           },
                         ),
                       ),
                       //エンターアイコンを変更
                       textInputAction: TextInputAction.search,
                       onFieldSubmitted: (String value) async {
-                        if (_formKey.currentState.validate()) setState(() {});;
+                        if (_formKey.currentState.validate()) setState(() {});
+                        ;
                       },
                       validator: (String value) {
                         if (value.isEmpty) {
@@ -80,16 +80,17 @@ class LookupTeamPageState extends State<LookupTeamPage> {
     );
   }
 
-  Widget _showsearchResults(){
-    if(_teamNameField.text != ""){
+  Widget _showsearchResults() {
+    if (_teamNameField.text != "") {
       return FutureBuilder(
         future: _search(),
-        builder: (BuildContext context, AsyncSnapshot<List<DocumentSnapshot>> snapshots){
+        builder: (BuildContext context,
+            AsyncSnapshot<List<DocumentSnapshot>> snapshots) {
           final Size size = MediaQuery.of(context).size;
           if (snapshots.hasData) {
-            if(snapshots.data.length == 0){
+            if (snapshots.data.length == 0) {
               return Text("該当チームなし");
-            } else{
+            } else {
               return Container(
                 height: size.height * (2 / 3),
                 child: Scrollbar(
@@ -97,40 +98,8 @@ class LookupTeamPageState extends State<LookupTeamPage> {
                       shrinkWrap: true,
                       itemCount: snapshots.data.length,
                       itemBuilder: (context, int index) {
-//                        return Container(
-//                          child: Column(
-//                            children: [
-//                              Text(
-//                                "チーム名 " + snapshots.data[index].data["team_name"].toString(),
-//                                style: TextStyle(
-//                                  fontSize: 20,
-//                                ),
-//                              ),
-//                              Visibility(
-//                                visible: snapshots.data[index].data["team_overview"]!=null,
-//                                child: Text(
-//                                  "概要 " + snapshots.data[index].data["team_overview"].toString(),
-//                                  style: TextStyle(
-//                                    fontSize: 20,
-//                                  ),
-//                                ),
-//                              ),
-//                              Visibility(
-//                                visible: snapshots.data[index].data["goal"]!=null,
-//                                child: Text(
-//                                  "目標 " + snapshots.data[index].data["goal"].toString() + "km",
-//                                  style: TextStyle(
-//                                    fontSize: 20,
-//                                  ),
-//                                ),
-//                              ),
-//                              JoinButton(snapshots.data[index].data["team_name"].toString()),
-//                            ],
-//                          ),
-//                        );
                         return TeamCard(snapshots.data[index]);
-                      }
-                  ),
+                      }),
                 ),
               );
             }
@@ -139,7 +108,7 @@ class LookupTeamPageState extends State<LookupTeamPage> {
           }
         },
       );
-    } else{
+    } else {
       return Container();
     }
   }
@@ -148,12 +117,11 @@ class LookupTeamPageState extends State<LookupTeamPage> {
     //結果を格納するリストを初期化する
     List<DocumentSnapshot> result = [];
     // 全チームを検索する
-    QuerySnapshot docs = await Firestore.instance
-        .collection("teams")
-        .getDocuments();
+    QuerySnapshot docs =
+        await Firestore.instance.collection("teams").getDocuments();
     // すでに参加しているチームをリストに格納する
     await docs.documents.forEach((doc) {
-      if(_teamSearch(doc)){
+      if (_teamSearch(doc)) {
         result.add(doc);
       }
     });
@@ -177,13 +145,14 @@ class LookupTeamPageState extends State<LookupTeamPage> {
     // すでに参加していたらfalseを返す
     if (_joinedTeamList.contains(snapshot.data["team_name"].toString())) {
       return false;
-    }
-    else {
+    } else {
       // チーム名か概要に入力された文字列が含まれていたらtrueを返す
       if (snapshot.data["team_name"].toString().contains(_teamNameField.text)) {
         return true;
-      } else if(snapshot.data["team_overview"] != null &&
-          snapshot.data["team_overview"].toString().contains(_teamNameField.text)){
+      } else if (snapshot.data["team_overview"] != null &&
+          snapshot.data["team_overview"]
+              .toString()
+              .contains(_teamNameField.text)) {
         return true;
       }
       // ヒットなし

--- a/lib/Pages/LookupTeamPage/lookup_team_page.dart
+++ b/lib/Pages/LookupTeamPage/lookup_team_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:the4thdayofmikkabozu/user_data.dart' as userData;
+import 'package:the4thdayofmikkabozu/Pages/LookupTeamPage/team_card.dart';
 import 'package:the4thdayofmikkabozu/Pages/LookupTeamPage/join_button.dart';
 
 class LookupTeamPage extends StatefulWidget {
@@ -96,37 +97,38 @@ class LookupTeamPageState extends State<LookupTeamPage> {
                       shrinkWrap: true,
                       itemCount: snapshots.data.length,
                       itemBuilder: (context, int index) {
-                        return Container(
-                          child: Column(
-                            children: [
-                              Text(
-                                "チーム名 " + snapshots.data[index].data["team_name"].toString(),
-                                style: TextStyle(
-                                  fontSize: 20,
-                                ),
-                              ),
-                              Visibility(
-                                visible: snapshots.data[index].data["team_overview"]!=null,
-                                child: Text(
-                                  "概要 " + snapshots.data[index].data["team_overview"].toString(),
-                                  style: TextStyle(
-                                    fontSize: 20,
-                                  ),
-                                ),
-                              ),
-                              Visibility(
-                                visible: snapshots.data[index].data["goal"]!=null,
-                                child: Text(
-                                  "目標 " + snapshots.data[index].data["goal"].toString() + "km",
-                                  style: TextStyle(
-                                    fontSize: 20,
-                                  ),
-                                ),
-                              ),
-                              JoinButton(snapshots.data[index].data["team_name"].toString()),
-                            ],
-                          ),
-                        );
+//                        return Container(
+//                          child: Column(
+//                            children: [
+//                              Text(
+//                                "チーム名 " + snapshots.data[index].data["team_name"].toString(),
+//                                style: TextStyle(
+//                                  fontSize: 20,
+//                                ),
+//                              ),
+//                              Visibility(
+//                                visible: snapshots.data[index].data["team_overview"]!=null,
+//                                child: Text(
+//                                  "概要 " + snapshots.data[index].data["team_overview"].toString(),
+//                                  style: TextStyle(
+//                                    fontSize: 20,
+//                                  ),
+//                                ),
+//                              ),
+//                              Visibility(
+//                                visible: snapshots.data[index].data["goal"]!=null,
+//                                child: Text(
+//                                  "目標 " + snapshots.data[index].data["goal"].toString() + "km",
+//                                  style: TextStyle(
+//                                    fontSize: 20,
+//                                  ),
+//                                ),
+//                              ),
+//                              JoinButton(snapshots.data[index].data["team_name"].toString()),
+//                            ],
+//                          ),
+//                        );
+                        return TeamCard(snapshots.data[index]);
                       }
                   ),
                 ),

--- a/lib/Pages/LookupTeamPage/team_card.dart
+++ b/lib/Pages/LookupTeamPage/team_card.dart
@@ -1,5 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
+import 'package:the4thdayofmikkabozu/Pages/LookupTeamPage/join_button.dart';
 
 class TeamCard extends StatelessWidget{
   DocumentSnapshot _snapshot;
@@ -7,6 +8,72 @@ class TeamCard extends StatelessWidget{
 
   @override
   Widget build(BuildContext context){
-    return Container();
+    return Card(
+        margin: EdgeInsets.all(10.0),
+        child: Container(
+          width: 200,
+          height: 100,
+          child: Row(
+            children: <Widget>[
+              Column(
+                children: <Widget>[
+                  Text(_snapshot.data["team_name"].toString()),
+                  TeamOverview(_snapshot.data["team_overview"].toString()),
+                ],
+              ),
+              Spacer(),
+              Column(
+                children: <Widget>[
+                  Row(
+                    children: <Widget>[
+                      teamGoal(_snapshot.data["goal"].toString()),
+                      teamMemberNum(_snapshot.data["user_num"].toString())
+                    ],
+                  ),
+                  JoinButton(_snapshot.data["team_name"].toString()),
+                ],
+              ),
+            ],
+          ),
+        )
+    );
+  }
+
+  Widget TeamOverview(String teamOverview){
+    if(teamOverview == "null"){
+      return Container();
+    }
+    return Text("概要：" + teamOverview);
+  }
+
+  Widget teamGoal(String goal) {
+    if(goal == "null"){
+      return Container();
+    }
+    return Row(
+      children: <Widget>[
+        Image.asset(
+          'images/flag-icon.png',
+          height: 16.0,
+          width: 16.0,
+        ),
+        Text(goal + "km"),
+      ],
+    );
+  }
+
+  Widget teamMemberNum(String userNum) {
+    if(userNum == "null"){
+      return Container();
+    }
+    return Row(
+      children: <Widget>[
+        Icon(
+            Icons.people_outline
+        ),
+        Text(userNum + "人"),
+      ],
+    );
   }
 }
+

--- a/lib/Pages/LookupTeamPage/team_card.dart
+++ b/lib/Pages/LookupTeamPage/team_card.dart
@@ -1,0 +1,12 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+
+class TeamCard extends StatelessWidget{
+  DocumentSnapshot _snapshot;
+  TeamCard(this._snapshot): super();
+
+  @override
+  Widget build(BuildContext context){
+    return Container();
+  }
+}

--- a/lib/Pages/LookupTeamPage/team_card.dart
+++ b/lib/Pages/LookupTeamPage/team_card.dart
@@ -2,52 +2,62 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:the4thdayofmikkabozu/Pages/LookupTeamPage/join_button.dart';
 
-class TeamCard extends StatelessWidget{
+class TeamCard extends StatelessWidget {
   DocumentSnapshot _snapshot;
-  TeamCard(this._snapshot): super();
+  TeamCard(this._snapshot) : super();
 
   @override
-  Widget build(BuildContext context){
+  Widget build(BuildContext context) {
     return Card(
-        margin: EdgeInsets.all(10.0),
+        margin: EdgeInsets.all(8.0),
         child: Container(
-          width: 200,
           height: 100,
-          child: Row(
-            children: <Widget>[
-              Column(
-                children: <Widget>[
-                  Text(_snapshot.data["team_name"].toString()),
-                  TeamOverview(_snapshot.data["team_overview"].toString()),
-                ],
-              ),
-              Spacer(),
-              Column(
-                children: <Widget>[
-                  Row(
-                    children: <Widget>[
-                      teamGoal(_snapshot.data["goal"].toString()),
-                      teamMemberNum(_snapshot.data["user_num"].toString())
-                    ],
-                  ),
-                  JoinButton(_snapshot.data["team_name"].toString()),
-                ],
-              ),
-            ],
+          child: Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Row(
+              children: <Widget>[
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Text(
+                      _snapshot.data["team_name"].toString(),
+                      style: TextStyle(fontSize: 18),
+                    ),
+                    TeamOverview(_snapshot.data["team_overview"].toString()),
+                  ],
+                ),
+                Spacer(),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: <Widget>[
+                    Row(
+                      children: <Widget>[
+                        teamGoal(_snapshot.data["goal"].toString()),
+                        teamMemberNum(_snapshot.data["user_num"].toString())
+                      ],
+                    ),
+                    Spacer(),
+                    JoinButton(_snapshot.data["team_name"].toString()),
+                  ],
+                ),
+              ],
+            ),
           ),
-        )
+        ));
+  }
+
+  Widget TeamOverview(String teamOverview) {
+    if (teamOverview == "null") {
+      return Container();
+    }
+    return Text(
+      "概要：" + teamOverview,
+      style: TextStyle(color: Colors.black54),
     );
   }
 
-  Widget TeamOverview(String teamOverview){
-    if(teamOverview == "null"){
-      return Container();
-    }
-    return Text("概要：" + teamOverview);
-  }
-
   Widget teamGoal(String goal) {
-    if(goal == "null"){
+    if (goal == "null") {
       return Container();
     }
     return Row(
@@ -63,17 +73,14 @@ class TeamCard extends StatelessWidget{
   }
 
   Widget teamMemberNum(String userNum) {
-    if(userNum == "null"){
+    if (userNum == "null") {
       return Container();
     }
     return Row(
       children: <Widget>[
-        Icon(
-            Icons.people_outline
-        ),
+        Icon(Icons.people_outline),
         Text(userNum + "人"),
       ],
     );
   }
 }
-

--- a/lib/Pages/TeamCreatePage/team_create_page.dart
+++ b/lib/Pages/TeamCreatePage/team_create_page.dart
@@ -124,6 +124,7 @@ class TeamCreatePageState extends State<TeamCreatePage> {
           'team_name': _nameController.text,
           'goal': int.parse(_goalController.text),
           'team_overview': _overviewController.text,
+          'user_num': 1,
         });
 
     Firestore.instance


### PR DESCRIPTION
# バックログアイテムの情報
#157 

作成者：@Yamakatsu63, @NishidaYujiro 

## タスク
- [x] カードウィジェットを返すクラスの作成
- [x] 受けとった情報をもとにチーム名、概要、目標、人数を表示する
- [x] 参加時にチームの人数を増やす
- [x] チーム作成時にチームの人数を格納するフィールドを作成する
