### PR TITLE
管理者が概要と目標を変更できるようにする

### DIFF
--- a/lib/Pages/TeamCreatePage/team_create_page.dart
+++ b/lib/Pages/TeamCreatePage/team_create_page.dart
@@ -1,8 +1,7 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:fluttertoast/fluttertoast.dart';
-import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:the4thdayofmikkabozu/user_data.dart' as userData;
-import 'package:the4thdayofmikkabozu/Pages/TeamMainPage/team_main_page.dart';
 
 class TeamCreatePage extends StatefulWidget {
   final String title = 'チーム作成';
@@ -49,7 +48,7 @@ class TeamCreatePageState extends State<TeamCreatePage> {
                   TextFormField(
                     controller: _overviewController,
                     decoration:
-                    const InputDecoration(labelText: 'チームの概要を入力してください'),
+                        const InputDecoration(labelText: 'チームの概要を入力してください'),
                     validator: (String value) {
                       if (value.isEmpty) {
                         return '登録にはチームの概要が必要です';
@@ -61,11 +60,11 @@ class TeamCreatePageState extends State<TeamCreatePage> {
                     controller: _goalController,
                     keyboardType: TextInputType.number,
                     decoration:
-                    const InputDecoration(labelText: 'チームの目標を入力してください'),
+                        const InputDecoration(labelText: 'チームの目標を入力してください'),
                     validator: (String value) {
                       if (value.isEmpty) {
                         return '登録にはチームの目標が必要です';
-                      } else if (_goalController.text.contains(',')){
+                      } else if (_goalController.text.contains(',')) {
                         return '目標に","を含めないでください';
                       }
                       return null;
@@ -92,7 +91,8 @@ class TeamCreatePageState extends State<TeamCreatePage> {
                                 updateDataUserData();
                                 // 2ページ前に戻る
                                 int count = 0;
-                                Navigator.of(context).popUntil((_) => count++ >= 2);
+                                Navigator.of(context)
+                                    .popUntil((_) => count++ >= 2);
                               } else {
                                 Fluttertoast.showToast(
                                   msg: 'すでに使用されています',
@@ -124,11 +124,12 @@ class TeamCreatePageState extends State<TeamCreatePage> {
         .collection('teams')
         .document(_nameController.text)
         .setData(<String, dynamic>{
-          'team_name': _nameController.text,
-          'goal': int.parse(_goalController.text),
-          'team_overview': _overviewController.text,
-          'user_num': 1,
-        });
+      'team_name': _nameController.text,
+      'goal': int.parse(_goalController.text),
+      'team_overview': _overviewController.text,
+      'user_num': 1,
+      'admin': _email,
+    });
 
     Firestore.instance
         .collection('teams')
@@ -146,10 +147,10 @@ class TeamCreatePageState extends State<TeamCreatePage> {
         .collection('teams')
         .document(_nameController.text)
         .setData(<String, dynamic>{
-          'team_name': _nameController.text,
-          'goal': int.parse(_goalController.text),
-          'team_overview': _overviewController.text,
-        });
+      'team_name': _nameController.text,
+      'goal': int.parse(_goalController.text),
+      'team_overview': _overviewController.text,
+    });
   }
 
   Future<bool> checkUniqueTeamName(String candidateName) async {

--- a/lib/Pages/TeamPage/goal_manager.dart
+++ b/lib/Pages/TeamPage/goal_manager.dart
@@ -5,9 +5,9 @@ import 'package:flutter_picker/flutter_picker.dart';
 
 class GoalManager extends StatelessWidget {
   String _teamName;
-  bool isAdmin;
+  bool _isAdmin;
 
-  GoalManager(this._teamName, this.isAdmin);
+  GoalManager(this._teamName, this._isAdmin);
 
   @override
   Widget build(BuildContext context) {
@@ -28,7 +28,7 @@ class GoalManager extends StatelessWidget {
           children: <Widget>[
             Center(child: _showGoal()),
             Visibility(
-              visible: isAdmin,
+              visible: _isAdmin,
               child: IconButton(
                   icon: Icon(Icons.mode_edit),
                   onPressed: () async {
@@ -60,23 +60,16 @@ class GoalManager extends StatelessWidget {
 
   void _setGoal(dynamic goal) {
     //Firebaseのteamsに目標を設定する
-    Firestore.instance
-        .collection('teams')
-        .document(_teamName)
-        .updateData(<String, dynamic>{'goal': goal});
+    Firestore.instance.collection('teams').document(_teamName).updateData(<String, dynamic>{'goal': goal});
   }
 
   Widget _showGoal() {
     //Firestoreから目標を取得して表示
     return StreamBuilder<DocumentSnapshot>(
         //表示したいFiresotreの保存先を指定
-        stream: Firestore.instance
-            .collection('teams')
-            .document((_teamName))
-            .snapshots(),
+        stream: Firestore.instance.collection('teams').document((_teamName)).snapshots(),
         //streamが更新されるたびに呼ばれる
-        builder:
-            (BuildContext context, AsyncSnapshot<DocumentSnapshot> snapshot) {
+        builder: (BuildContext context, AsyncSnapshot<DocumentSnapshot> snapshot) {
           //データが取れていない時の処理
           if (!snapshot.hasData) return const Text('Loading...');
           if (snapshot.data["goal"] != null) {

--- a/lib/Pages/TeamPage/goal_manager.dart
+++ b/lib/Pages/TeamPage/goal_manager.dart
@@ -5,8 +5,9 @@ import 'package:flutter_picker/flutter_picker.dart';
 
 class GoalManager extends StatelessWidget {
   String _teamName;
+  bool isAdmin;
 
-  GoalManager(this._teamName);
+  GoalManager(this._teamName, this.isAdmin);
 
   @override
   Widget build(BuildContext context) {
@@ -26,12 +27,15 @@ class GoalManager extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
             Center(child: _showGoal()),
-            IconButton(
-                icon: Icon(Icons.mode_edit),
-                onPressed: () async {
-                  //目標変更
-                  showPickerNumber(context);
-                }),
+            Visibility(
+              visible: isAdmin,
+              child: IconButton(
+                  icon: Icon(Icons.mode_edit),
+                  onPressed: () async {
+                    //目標変更
+                    showPickerNumber(context);
+                  }),
+            ),
           ],
         ),
       ],

--- a/lib/Pages/TeamPage/members_record.dart
+++ b/lib/Pages/TeamPage/members_record.dart
@@ -22,11 +22,7 @@ class MembersRecord extends StatelessWidget {
   Widget getMembers(BuildContext context) {
     return StreamBuilder<QuerySnapshot>(
         //表示したいFiresotreの保存先を指定
-        stream: Firestore.instance
-            .collection('teams')
-            .document(_teamName)
-            .collection('users')
-            .snapshots(),
+        stream: Firestore.instance.collection('teams').document(_teamName).collection('users').snapshots(),
         //streamが更新されるたびに呼ばれる
         builder: (BuildContext context, AsyncSnapshot<QuerySnapshot> snapshot) {
           //データが取れていない時の処理
@@ -42,13 +38,11 @@ class MembersRecord extends StatelessWidget {
                 // 個人の記録の取得
                 return FutureBuilder(
                     future: getMemberRecord(snapshot.data, goalSnapshot.data),
-                    builder: (BuildContext context,
-                        AsyncSnapshot<Map> memberSnapshot) {
+                    builder: (BuildContext context, AsyncSnapshot<Map> memberSnapshot) {
                       if (memberSnapshot.hasData) {
                         print(memberSnapshot.data);
                         int achievedMemberNum = 0;
-                        memberSnapshot.data
-                            .forEach((dynamic key, dynamic value) {
+                        memberSnapshot.data.forEach((dynamic key, dynamic value) {
                           if (value[0] as bool) {
                             achievementNum++;
                           }
@@ -64,9 +58,7 @@ class MembersRecord extends StatelessWidget {
                               ),
                             ),
                             Text(
-                              achievementNum.toString() +
-                                  "/" +
-                                  snapshot.data.documents.length.toString(),
+                              achievementNum.toString() + "/" + snapshot.data.documents.length.toString(),
                               style: TextStyle(
                                 fontWeight: FontWeight.bold,
                                 fontSize: 30,
@@ -77,13 +69,11 @@ class MembersRecord extends StatelessWidget {
                                 Padding(
                                   padding: EdgeInsets.all(5.0),
                                   child: new LinearPercentIndicator(
-                                    width:
-                                        MediaQuery.of(context).size.width - 50,
+                                    width: MediaQuery.of(context).size.width - 50,
                                     animation: true,
                                     lineHeight: 20.0,
                                     animationDuration: 2000,
-                                    percent: achievementNum /
-                                        snapshot.data.documents.length,
+                                    percent: achievementNum / snapshot.data.documents.length,
 //                                  center: Text(achievementNum.toString() + "/" + snapshot.data.documents.length.toString()),
                                     linearStrokeCap: LinearStrokeCap.roundAll,
                                     progressColor: hex.HexColor("f17300"),
@@ -111,15 +101,11 @@ class MembersRecord extends StatelessWidget {
                                   shrinkWrap: true,
                                   itemCount: snapshot.data.documents.length,
                                   itemBuilder: (context, int index) {
-                                    String userEmail = snapshot
-                                        .data.documents[index].documentID
-                                        .toString();
+                                    String userEmail = snapshot.data.documents[index].documentID.toString();
                                     String userName = "Guest";
                                     print(memberSnapshot.data[userEmail][1]);
-                                    if (memberSnapshot.data[userEmail][1] !=
-                                        "null") {
-                                      userName = memberSnapshot.data[userEmail]
-                                          [1] as String;
+                                    if (memberSnapshot.data[userEmail][1] != "null") {
+                                      userName = memberSnapshot.data[userEmail][1] as String;
                                     }
                                     return ListTile(
                                       leading: Icon(
@@ -127,8 +113,7 @@ class MembersRecord extends StatelessWidget {
                                         size: 50,
                                       ),
                                       trailing: Visibility(
-                                        visible: memberSnapshot.data[userEmail]
-                                            [0] as bool,
+                                        visible: memberSnapshot.data[userEmail][0] as bool,
                                         child: Image.asset(
                                           'images/flag-icon.png',
                                           height: 30.0,
@@ -150,8 +135,7 @@ class MembersRecord extends StatelessWidget {
                                       onTap: () => Navigator.push<dynamic>(
                                           context,
                                           MaterialPageRoute<dynamic>(
-                                            builder: (context) =>
-                                                MemberPage(userEmail, userName),
+                                            builder: (context) => MemberPage(userEmail, userName),
                                           )),
                                     );
                                   },
@@ -173,10 +157,7 @@ class MembersRecord extends StatelessWidget {
   }
 
   Future<int> getGoal() async {
-    var snapshot = await Firestore.instance
-        .collection('teams')
-        .document((_teamName))
-        .get();
+    var snapshot = await Firestore.instance.collection('teams').document((_teamName)).get();
     return snapshot.data['goal'] as int;
   }
 
@@ -190,17 +171,12 @@ class MembersRecord extends StatelessWidget {
           .collection('users')
           .document(data.documents[i].documentID)
           .collection('records')
-          .where("timestamp",
-              isGreaterThanOrEqualTo:
-                  Timestamp.fromDate(getLastSundayDataTime()))
+          .where("timestamp", isGreaterThanOrEqualTo: Timestamp.fromDate(getLastSundayDataTime()))
           .getDocuments();
-      DocumentSnapshot userSnapshot = await Firestore.instance
-          .collection('users')
-          .document(data.documents[i].documentID)
-          .get();
+      DocumentSnapshot userSnapshot =
+          await Firestore.instance.collection('users').document(data.documents[i].documentID).get();
       for (int j = 0; j < recordSnapshots.documents.length; j++) {
-        totalDistance +=
-            recordSnapshots.documents[j].data['distance'] as double;
+        totalDistance += recordSnapshots.documents[j].data['distance'] as double;
       }
       // 目標を達成しているかの確認
       if (((totalDistance / 100.0).round() / 10) >= goal) {
@@ -208,8 +184,7 @@ class MembersRecord extends StatelessWidget {
       } else {
         hasMemberAchieved.add(false);
       }
-      hasMemberAchieved
-          .add(userSnapshot.data['name'].toString()); //0にbool,1にname
+      hasMemberAchieved.add(userSnapshot.data['name'].toString()); //0にbool,1にname
       userMap[data.documents[i].documentID] = hasMemberAchieved;
     }
     return userMap;

--- a/lib/Pages/TeamPage/members_record.dart
+++ b/lib/Pages/TeamPage/members_record.dart
@@ -1,15 +1,15 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:the4thdayofmikkabozu/Pages/MemberPage/member_page.dart';
-import 'package:the4thdayofmikkabozu/user_data.dart' as userData;
 import 'package:percent_indicator/percent_indicator.dart';
+import 'package:the4thdayofmikkabozu/Pages/MemberPage/member_page.dart';
 import 'package:the4thdayofmikkabozu/hex_color.dart' as hex;
 
 class MembersRecord extends StatelessWidget {
   String _teamName;
+  String _adminEmail;
 
-  MembersRecord(this._teamName);
+  MembersRecord(this._teamName, this._adminEmail);
 
   @override
   Widget build(BuildContext context) {
@@ -41,120 +41,130 @@ class MembersRecord extends StatelessWidget {
               if (goalSnapshot.hasData) {
                 // 個人の記録の取得
                 return FutureBuilder(
-                  future: getMemberRecord(snapshot.data, goalSnapshot.data),
-                  builder: (BuildContext context, AsyncSnapshot<Map> memberSnapshot) {
-                    if (memberSnapshot.hasData) {
-                      print(memberSnapshot.data);
-                      int achievedMemberNum = 0;
-                      memberSnapshot.data.forEach((dynamic key, dynamic value) {
-                        if(value[0] as bool){
-                          achievementNum++;
-                        }
-                      });
-                      return Column(
-                        children: [
-                          Text(
-                            '到達人数',
-                            style: TextStyle(
-                              fontWeight: FontWeight.bold,
-                              fontSize: 20,
-                              color: Theme.of(context).primaryColor,
+                    future: getMemberRecord(snapshot.data, goalSnapshot.data),
+                    builder: (BuildContext context,
+                        AsyncSnapshot<Map> memberSnapshot) {
+                      if (memberSnapshot.hasData) {
+                        print(memberSnapshot.data);
+                        int achievedMemberNum = 0;
+                        memberSnapshot.data
+                            .forEach((dynamic key, dynamic value) {
+                          if (value[0] as bool) {
+                            achievementNum++;
+                          }
+                        });
+                        return Column(
+                          children: [
+                            Text(
+                              '到達人数',
+                              style: TextStyle(
+                                fontWeight: FontWeight.bold,
+                                fontSize: 20,
+                                color: Theme.of(context).primaryColor,
+                              ),
                             ),
-                          ),
-                          Text(
-                            achievementNum.toString() + "/" + snapshot.data.documents.length.toString(),
-                            style: TextStyle(
-                              fontWeight: FontWeight.bold,
-                              fontSize: 30,
+                            Text(
+                              achievementNum.toString() +
+                                  "/" +
+                                  snapshot.data.documents.length.toString(),
+                              style: TextStyle(
+                                fontWeight: FontWeight.bold,
+                                fontSize: 30,
+                              ),
                             ),
-                          ),
-                          Row(
-                            children: [
-                              Padding(
-                                padding: EdgeInsets.all(5.0),
-                                child: new LinearPercentIndicator(
-                                  width: MediaQuery.of(context).size.width - 50,
-                                  animation: true,
-                                  lineHeight: 20.0,
-                                  animationDuration: 2000,
-                                  percent: achievementNum/snapshot.data.documents.length,
+                            Row(
+                              children: [
+                                Padding(
+                                  padding: EdgeInsets.all(5.0),
+                                  child: new LinearPercentIndicator(
+                                    width:
+                                        MediaQuery.of(context).size.width - 50,
+                                    animation: true,
+                                    lineHeight: 20.0,
+                                    animationDuration: 2000,
+                                    percent: achievementNum /
+                                        snapshot.data.documents.length,
 //                                  center: Text(achievementNum.toString() + "/" + snapshot.data.documents.length.toString()),
-                                  linearStrokeCap: LinearStrokeCap.roundAll,
-                                  progressColor: hex.HexColor("f17300"),
-                                  trailing: Image.asset(
-                                    'images/flag-icon.png',
-                                    height: 30.0,
-                                    width: 30.0,
+                                    linearStrokeCap: LinearStrokeCap.roundAll,
+                                    progressColor: hex.HexColor("f17300"),
+                                    trailing: Image.asset(
+                                      'images/flag-icon.png',
+                                      height: 30.0,
+                                      width: 30.0,
+                                    ),
                                   ),
                                 ),
-                              ),
-                            ],
-                          ),
-                          Text(
-                            'メンバー',
-                            style: TextStyle(
-                              fontWeight: FontWeight.bold,
-                              fontSize: 20,
-                              color: Theme.of(context).primaryColor,
+                              ],
                             ),
-                          ),
-                          Container(
-                            height: size.height * (1 / 3),
-                            child: Scrollbar(
-                              child: ListView.builder(
-                                shrinkWrap: true,
-                                itemCount: snapshot.data.documents.length,
-                                itemBuilder: (context, int index) {
-                                  String userEmail =
-                                      snapshot.data.documents[index].documentID.toString();
-                                  String userName = "Guest";
-                                  print(memberSnapshot.data[userEmail][1]);
-                                  if(memberSnapshot.data[userEmail][1] != "null") {
-                                    userName = memberSnapshot.data[userEmail][1] as String;
-                                  }
-                                  if(memberSnapshot.data[userEmail][0] as bool){
+                            Text(
+                              'メンバー',
+                              style: TextStyle(
+                                fontWeight: FontWeight.bold,
+                                fontSize: 20,
+                                color: Theme.of(context).primaryColor,
+                              ),
+                            ),
+                            Container(
+                              height: size.height * (1 / 3),
+                              child: Scrollbar(
+                                child: ListView.builder(
+                                  shrinkWrap: true,
+                                  itemCount: snapshot.data.documents.length,
+                                  itemBuilder: (context, int index) {
+                                    String userEmail = snapshot
+                                        .data.documents[index].documentID
+                                        .toString();
+                                    String userName = "Guest";
+                                    print(memberSnapshot.data[userEmail][1]);
+                                    if (memberSnapshot.data[userEmail][1] !=
+                                        "null") {
+                                      userName = memberSnapshot.data[userEmail]
+                                          [1] as String;
+                                    }
                                     return ListTile(
                                       leading: Icon(
                                         Icons.account_circle,
                                         size: 50,
                                       ),
-                                      trailing: Image.asset(
-                                        'images/flag-icon.png',
-                                        height: 30.0,
-                                        width: 30.0,
+                                      trailing: Visibility(
+                                        visible: memberSnapshot.data[userEmail]
+                                            [0] as bool,
+                                        child: Image.asset(
+                                          'images/flag-icon.png',
+                                          height: 30.0,
+                                          width: 30.0,
+                                        ),
                                       ),
-                                      title: Text(userName),
+                                      title: Row(
+                                        children: <Widget>[
+                                          Text(userName),
+                                          Visibility(
+                                            visible: userEmail == _adminEmail,
+                                            child: Icon(
+                                              Icons.star,
+                                              color: Colors.amber,
+                                            ),
+                                          ),
+                                        ],
+                                      ),
                                       onTap: () => Navigator.push<dynamic>(
                                           context,
                                           MaterialPageRoute<dynamic>(
-                                            builder: (context) => MemberPage(userEmail, userName),
+                                            builder: (context) =>
+                                                MemberPage(userEmail, userName),
                                           )),
                                     );
-                                  } else{
-                                    return ListTile(
-                                      leading: Icon(
-                                        Icons.account_circle,
-                                        size: 50,
-                                      ),
-                                      title: Text(userName),
-                                      onTap: () => Navigator.push<dynamic>(
-                                          context,
-                                          MaterialPageRoute<dynamic>(
-                                            builder: (context) => MemberPage(userEmail, userName),
-                                          )),
-                                    );
-                                  }
-                                },
+                                  },
+                                ),
                               ),
                             ),
-                          ),
-                        ],
-                      );
-                    } else {
-                      return Text("record loading...");
-                    }
-                  });
-              } else{
+                          ],
+                        );
+                      } else {
+                        return Text("record loading...");
+                      }
+                    });
+              } else {
                 return Text("goal loading...");
               }
             },
@@ -162,7 +172,7 @@ class MembersRecord extends StatelessWidget {
         });
   }
 
-  Future<int> getGoal() async{
+  Future<int> getGoal() async {
     var snapshot = await Firestore.instance
         .collection('teams')
         .document((_teamName))
@@ -170,32 +180,36 @@ class MembersRecord extends StatelessWidget {
     return snapshot.data['goal'] as int;
   }
 
-  Future<Map> getMemberRecord(QuerySnapshot data, int goal) async{
+  Future<Map> getMemberRecord(QuerySnapshot data, int goal) async {
     // マップの初期化
     Map<String, List> userMap = {};
-    for(int i=0; i<data.documents.length; i++){
+    for (int i = 0; i < data.documents.length; i++) {
       List<dynamic> hasMemberAchieved = List<dynamic>();
       double totalDistance = 0.0;
       QuerySnapshot recordSnapshots = await Firestore.instance
           .collection('users')
           .document(data.documents[i].documentID)
           .collection('records')
-          .where("timestamp", isGreaterThanOrEqualTo: Timestamp.fromDate(getLastSundayDataTime()))
+          .where("timestamp",
+              isGreaterThanOrEqualTo:
+                  Timestamp.fromDate(getLastSundayDataTime()))
           .getDocuments();
       DocumentSnapshot userSnapshot = await Firestore.instance
           .collection('users')
           .document(data.documents[i].documentID)
           .get();
-      for(int j=0; j<recordSnapshots.documents.length; j++){
-        totalDistance += recordSnapshots.documents[j].data['distance'] as double;
+      for (int j = 0; j < recordSnapshots.documents.length; j++) {
+        totalDistance +=
+            recordSnapshots.documents[j].data['distance'] as double;
       }
       // 目標を達成しているかの確認
-      if(((totalDistance / 100.0).round() / 10) >= goal){
+      if (((totalDistance / 100.0).round() / 10) >= goal) {
         hasMemberAchieved.add(true);
-      } else{
+      } else {
         hasMemberAchieved.add(false);
       }
-      hasMemberAchieved.add(userSnapshot.data['name'].toString());//0にbool,1にname
+      hasMemberAchieved
+          .add(userSnapshot.data['name'].toString()); //0にbool,1にname
       userMap[data.documents[i].documentID] = hasMemberAchieved;
     }
     return userMap;
@@ -209,7 +223,7 @@ class MembersRecord extends StatelessWidget {
     // 直前の日曜日まで日付を戻していく
     if (dResult.weekday != DateTime.sunday) {
       for (int i = 0; i < 7; ++i) {
-        dResult = dResult.subtract(Duration(days : 1));
+        dResult = dResult.subtract(Duration(days: 1));
         if (dResult.weekday == DateTime.sunday) {
           break;
         }

--- a/lib/Pages/TeamPage/overview_manager.dart
+++ b/lib/Pages/TeamPage/overview_manager.dart
@@ -4,12 +4,12 @@ import 'package:flutter/material.dart';
 
 class OverviewManager extends StatelessWidget {
   String _teamName;
-  bool isAdmin;
+  bool _isAdmin;
 
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
   final TextEditingController _overviewController = TextEditingController();
 
-  OverviewManager(this._teamName, this.isAdmin);
+  OverviewManager(this._teamName, this._isAdmin);
 
   @override
   Widget build(BuildContext context) {
@@ -38,13 +38,9 @@ class OverviewManager extends StatelessWidget {
     //Firestoreから目標を取得して表示
     return StreamBuilder<DocumentSnapshot>(
         //表示したいFiresotreの保存先を指定
-        stream: Firestore.instance
-            .collection('teams')
-            .document((_teamName))
-            .snapshots(),
+        stream: Firestore.instance.collection('teams').document((_teamName)).snapshots(),
         //streamが更新されるたびに呼ばれる
-        builder:
-            (BuildContext context, AsyncSnapshot<DocumentSnapshot> snapshot) {
+        builder: (BuildContext context, AsyncSnapshot<DocumentSnapshot> snapshot) {
           //データが取れていない時の処理
           if (!snapshot.hasData) return const Text('Loading...');
           if (snapshot.data["team_overview"] != null) {
@@ -57,7 +53,7 @@ class OverviewManager extends StatelessWidget {
                   ),
                 ),
                 Visibility(
-                  visible: isAdmin,
+                  visible: _isAdmin,
                   child: IconButton(
                       icon: Icon(Icons.mode_edit),
                       onPressed: () async {
@@ -70,8 +66,7 @@ class OverviewManager extends StatelessWidget {
                                 title: Text("チーム概要の変更"),
                                 children: [
                                   Padding(
-                                    padding: const EdgeInsets.only(
-                                        left: 8.0, right: 8.0),
+                                    padding: const EdgeInsets.only(left: 8.0, right: 8.0),
                                     child: TextFormField(
                                       controller: _overviewController,
                                       decoration: InputDecoration(
@@ -92,15 +87,9 @@ class OverviewManager extends StatelessWidget {
                                       FlatButton(
                                           child: Text("変更"),
                                           onPressed: () {
-                                            if (_formKey.currentState
-                                                .validate()) {
-                                              Firestore.instance
-                                                  .collection('teams')
-                                                  .document(_teamName)
-                                                  .updateData(<String, dynamic>{
-                                                'team_overview':
-                                                    _overviewController.text
-                                              });
+                                            if (_formKey.currentState.validate()) {
+                                              Firestore.instance.collection('teams').document(_teamName).updateData(
+                                                  <String, dynamic>{'team_overview': _overviewController.text});
                                               _overviewController.text = "";
                                               Navigator.pop(context);
                                             }

--- a/lib/Pages/TeamPage/team_page.dart
+++ b/lib/Pages/TeamPage/team_page.dart
@@ -72,7 +72,7 @@ class TeamPageState extends State<TeamPage> {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: <Widget>[
                     OverviewManager(_teamName),
-                    GoalManager(_teamName),
+                    GoalManager(_teamName, IsAdmin),
                     Container(
                       height: 10.0,
                     ),

--- a/lib/Pages/TeamPage/team_page.dart
+++ b/lib/Pages/TeamPage/team_page.dart
@@ -22,68 +22,77 @@ class TeamPageState extends State<TeamPage> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(_teamName),
-        actions: <Widget>[
-          IconButton(
-            icon: Icon(
-              Icons.exit_to_app,
-              color: Colors.white,
-            ),
-            onPressed: () async {
-              showDialog<dynamic>(
-                context: context,
-                builder: (context) {
-                  return AlertDialog(
-                    content: Text("「" + _teamName + "」" + "を抜けますか?"),
-                    actions: <Widget>[
-                      FlatButton(
-                        child: Text("はい"),
-                        onPressed: () {
-                          LeaveTeam();
-                          int count = 0;
-                          Navigator.of(context).popUntil((_) => count++ >= 2);
-                        }
-                      ),
-                      FlatButton(
-                        child: Text("キャンセル"),
-                        onPressed: () => Navigator.pop(context),
-                      ),
-                    ],
+    return FutureBuilder(
+      future: getAdmin(),
+      builder: (BuildContext context, AsyncSnapshot<String> adminSnapshot) {
+        if (!adminSnapshot.hasData) {
+          return Text('Loading...');
+        }
+        bool IsAdmin = userData.userEmail == adminSnapshot.data;
+        return Scaffold(
+          appBar: AppBar(
+            title: Text(_teamName),
+            actions: <Widget>[
+              IconButton(
+                icon: Icon(
+                  Icons.exit_to_app,
+                  color: Colors.white,
+                ),
+                onPressed: () async {
+                  showDialog<dynamic>(
+                    context: context,
+                    builder: (context) {
+                      return AlertDialog(
+                        content: Text("「" + _teamName + "」" + "を抜けますか?"),
+                        actions: <Widget>[
+                          FlatButton(
+                              child: Text("はい"),
+                              onPressed: () {
+                                LeaveTeam();
+                                int count = 0;
+                                Navigator.of(context)
+                                    .popUntil((_) => count++ >= 2);
+                              }),
+                          FlatButton(
+                            child: Text("キャンセル"),
+                            onPressed: () => Navigator.pop(context),
+                          ),
+                        ],
+                      );
+                    },
                   );
                 },
-              );
-            },
+              ),
+            ],
           ),
-        ],
-      ),
-      body: Center(
-        child: Padding(
-          padding: const EdgeInsets.only(top: 20.0),
-          child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                OverviewManager(_teamName),
-                GoalManager(_teamName),
-                Container(
-                  height: 10.0,
-                ),
-                MembersRecord(_teamName),
-              ]),
-        ),
-      ),
-        floatingActionButton:FloatingActionButton(
-          onPressed: () async {
-            await Navigator.push<dynamic>(
-                context,
-                MaterialPageRoute<dynamic>(
-                  builder: (context) => ChatPage(_teamName),
-                ));
-          },
-          child: Icon(Icons.chat),
-          backgroundColor: Colors.blue,
-        ),
+          body: Center(
+            child: Padding(
+              padding: const EdgeInsets.only(top: 20.0),
+              child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    OverviewManager(_teamName),
+                    GoalManager(_teamName),
+                    Container(
+                      height: 10.0,
+                    ),
+                    MembersRecord(_teamName),
+                  ]),
+            ),
+          ),
+          floatingActionButton: FloatingActionButton(
+            onPressed: () async {
+              await Navigator.push<dynamic>(
+                  context,
+                  MaterialPageRoute<dynamic>(
+                    builder: (context) => ChatPage(_teamName),
+                  ));
+            },
+            child: Icon(Icons.chat),
+            backgroundColor: Colors.blue,
+          ),
+        );
+      },
     );
   }
 
@@ -105,10 +114,8 @@ class TeamPageState extends State<TeamPage> {
         .delete();
 
     // チームの参加人数を取得
-    DocumentSnapshot snapshot = await Firestore.instance
-        .collection('teams')
-        .document(_teamName)
-        .get();
+    DocumentSnapshot snapshot =
+        await Firestore.instance.collection('teams').document(_teamName).get();
 
     // チームの参加人数を1増やしてプッシュ
     int userNum = (snapshot.data['user_num'] as int) - 1;
@@ -116,5 +123,13 @@ class TeamPageState extends State<TeamPage> {
         .collection('teams')
         .document(_teamName)
         .updateData(<String, num>{'user_num': userNum});
+  }
+
+  Future<String> getAdmin() async {
+    var snapshot = await Firestore.instance
+        .collection('teams')
+        .document((_teamName))
+        .get();
+    return snapshot.data['admin'].toString();
   }
 }

--- a/lib/Pages/TeamPage/team_page.dart
+++ b/lib/Pages/TeamPage/team_page.dart
@@ -22,13 +22,18 @@ class TeamPageState extends State<TeamPage> {
 
   @override
   Widget build(BuildContext context) {
-    return FutureBuilder(
-      future: getAdmin(),
-      builder: (BuildContext context, AsyncSnapshot<String> adminSnapshot) {
+    return StreamBuilder<DocumentSnapshot>(
+      stream: Firestore.instance
+          .collection('teams')
+          .document(_teamName)
+          .snapshots(),
+      builder: (BuildContext context,
+          AsyncSnapshot<DocumentSnapshot> adminSnapshot) {
         if (!adminSnapshot.hasData) {
           return Text('Loading...');
         }
-        bool IsAdmin = userData.userEmail == adminSnapshot.data;
+        bool isAdmin =
+            userData.userEmail == adminSnapshot.data['admin'].toString();
         return Scaffold(
           appBar: AppBar(
             title: Text(_teamName),
@@ -65,19 +70,22 @@ class TeamPageState extends State<TeamPage> {
               ),
             ],
           ),
-          body: Center(
-            child: Padding(
-              padding: const EdgeInsets.only(top: 20.0),
-              child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: <Widget>[
-                    OverviewManager(_teamName),
-                    GoalManager(_teamName, IsAdmin),
-                    Container(
-                      height: 10.0,
-                    ),
-                    MembersRecord(_teamName),
-                  ]),
+          body: SingleChildScrollView(
+            child: Center(
+              child: Padding(
+                padding: const EdgeInsets.only(top: 20.0),
+                child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      OverviewManager(_teamName, isAdmin),
+                      GoalManager(_teamName, isAdmin),
+                      Container(
+                        height: 10.0,
+                      ),
+                      MembersRecord(
+                          _teamName, adminSnapshot.data['admin'].toString()),
+                    ]),
+              ),
             ),
           ),
           floatingActionButton: FloatingActionButton(


### PR DESCRIPTION
# バックログアイテムの情報
#136 
作成者：@Yamakatsu63

## タスク
- [x] チーム作成時に作成者を管理者として登録する
- [x] チームページにアクセスしたときに自分が管理者かどうかを確認する
  - [x] 管理者だった時
    - [x] 概要を変更できるようにする
    - [x] 目標を変更できるようにする
  - [x] 管理者じゃなかったとき
    - [x] 概要を変更できないようにする
    - [x] 目標を変更できないようにする
- [x] メンバー一覧ウィジェットに管理者のメールアドレスを渡す
- [x] メンバー一覧で管理者にスターアイコンを付ける