### PR TITLE
管理者がチームを消せるようにします

### DIFF
--- a/lib/Pages/TeamPage/team_page.dart
+++ b/lib/Pages/TeamPage/team_page.dart
@@ -23,21 +23,45 @@ class TeamPageState extends State<TeamPage> {
   @override
   Widget build(BuildContext context) {
     return StreamBuilder<DocumentSnapshot>(
-      stream: Firestore.instance
-          .collection('teams')
-          .document(_teamName)
-          .snapshots(),
-      builder: (BuildContext context,
-          AsyncSnapshot<DocumentSnapshot> adminSnapshot) {
+      stream: Firestore.instance.collection('teams').document(_teamName).snapshots(),
+      builder: (BuildContext context, AsyncSnapshot<DocumentSnapshot> adminSnapshot) {
         if (!adminSnapshot.hasData) {
           return Text('Loading...');
         }
-        bool isAdmin =
-            userData.userEmail == adminSnapshot.data['admin'].toString();
+        bool isAdmin = userData.userEmail == adminSnapshot.data['admin'].toString();
         return Scaffold(
           appBar: AppBar(
             title: Text(_teamName),
             actions: <Widget>[
+              IconButton(
+                icon: Icon(
+                  Icons.delete_forever,
+                  color: Colors.white,
+                ),
+                onPressed: () async {
+                  showDialog<dynamic>(
+                    context: context,
+                    builder: (context) {
+                      return AlertDialog(
+                        content: Text("「" + _teamName + "」" + "を削除しますか?"),
+                        actions: <Widget>[
+                          FlatButton(
+                              child: Text("はい"),
+                              onPressed: () {
+                                // LeaveTeam();
+                                int count = 0;
+                                Navigator.of(context).popUntil((_) => count++ >= 2);
+                              }),
+                          FlatButton(
+                            child: Text("キャンセル"),
+                            onPressed: () => Navigator.pop(context),
+                          ),
+                        ],
+                      );
+                    },
+                  );
+                },
+              ),
               IconButton(
                 icon: Icon(
                   Icons.exit_to_app,
@@ -55,8 +79,7 @@ class TeamPageState extends State<TeamPage> {
                               onPressed: () {
                                 LeaveTeam();
                                 int count = 0;
-                                Navigator.of(context)
-                                    .popUntil((_) => count++ >= 2);
+                                Navigator.of(context).popUntil((_) => count++ >= 2);
                               }),
                           FlatButton(
                             child: Text("キャンセル"),
@@ -74,17 +97,14 @@ class TeamPageState extends State<TeamPage> {
             child: Center(
               child: Padding(
                 padding: const EdgeInsets.only(top: 20.0),
-                child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: <Widget>[
-                      OverviewManager(_teamName, isAdmin),
-                      GoalManager(_teamName, isAdmin),
-                      Container(
-                        height: 10.0,
-                      ),
-                      MembersRecord(
-                          _teamName, adminSnapshot.data['admin'].toString()),
-                    ]),
+                child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: <Widget>[
+                  OverviewManager(_teamName, isAdmin),
+                  GoalManager(_teamName, isAdmin),
+                  Container(
+                    height: 10.0,
+                  ),
+                  MembersRecord(_teamName, adminSnapshot.data['admin'].toString()),
+                ]),
               ),
             ),
           ),
@@ -122,22 +142,15 @@ class TeamPageState extends State<TeamPage> {
         .delete();
 
     // チームの参加人数を取得
-    DocumentSnapshot snapshot =
-        await Firestore.instance.collection('teams').document(_teamName).get();
+    DocumentSnapshot snapshot = await Firestore.instance.collection('teams').document(_teamName).get();
 
     // チームの参加人数を1増やしてプッシュ
     int userNum = (snapshot.data['user_num'] as int) - 1;
-    Firestore.instance
-        .collection('teams')
-        .document(_teamName)
-        .updateData(<String, num>{'user_num': userNum});
+    Firestore.instance.collection('teams').document(_teamName).updateData(<String, num>{'user_num': userNum});
   }
 
   Future<String> getAdmin() async {
-    var snapshot = await Firestore.instance
-        .collection('teams')
-        .document((_teamName))
-        .get();
+    var snapshot = await Firestore.instance.collection('teams').document((_teamName)).get();
     return snapshot.data['admin'].toString();
   }
 }

--- a/lib/Pages/TeamPage/team_page.dart
+++ b/lib/Pages/TeamPage/team_page.dart
@@ -48,7 +48,7 @@ class TeamPageState extends State<TeamPage> {
                           FlatButton(
                               child: Text("はい"),
                               onPressed: () {
-                                // LeaveTeam();
+                                DeleteTeam();
                                 int count = 0;
                                 Navigator.of(context).popUntil((_) => count++ >= 2);
                               }),
@@ -152,5 +152,22 @@ class TeamPageState extends State<TeamPage> {
   Future<String> getAdmin() async {
     var snapshot = await Firestore.instance.collection('teams').document((_teamName)).get();
     return snapshot.data['admin'].toString();
+  }
+
+  void DeleteTeam() {
+    //teamからusersサブコレクションを削除
+    Firestore.instance.collection('teams').document(_teamName).collection('users').getDocuments().then((snapshot) {
+      for (DocumentSnapshot ds in snapshot.documents) {
+        ds.reference.delete();
+      }
+    });
+    //teamからchatsサブコレクションを削除
+    Firestore.instance.collection('teams').document(_teamName).collection('chats').getDocuments().then((snapshot) {
+      for (DocumentSnapshot ds in snapshot.documents) {
+        ds.reference.delete();
+      }
+    });
+    //teamsからチームを削除
+    Firestore.instance.collection('teams').document(_teamName).delete();
   }
 }


### PR DESCRIPTION
# バックログアイテムの情報
#173 

作成者：tyanio

テスター：

## タスク
- [x] 管理者の時AppBarにゴミ箱アイコンを追加する
- [x] 押すとダイアログを表示するようにする
- [x] teamsから該当するteamを消す(teamsのサブコレクションをすべて消す必要あり)
  - [x] usersを消す
  - [x] chatsを消す
- [x] 該当userから該当するteamを消す
