### PR TITLE
管理者権限の譲渡

### DIFF
--- a/lib/Pages/TeamPage/team_page.dart
+++ b/lib/Pages/TeamPage/team_page.dart
@@ -125,7 +125,7 @@ class TeamPageState extends State<TeamPage> {
     DocumentSnapshot snapshot =
         await Firestore.instance.collection('teams').document(_teamName).get();
 
-    // チームの参加人数を1増やしてプッシュ
+    // チームの参加人数を1減らしてプッシュ
     int userNum = (snapshot.data['user_num'] as int) - 1;
     Firestore.instance
         .collection('teams')


### PR DESCRIPTION
#174 

作成者：@Yamakatsu63, @NishidaYujiro 

## タスク
- [x] 管理者がチームのページにアクセスしたら自分以外のメンバーに[PopupMenuButton](https://api.flutter.dev/flutter/material/PopupMenuButton-class.html)を表示する
- [x] PopupMenuButtonの中身を管理者権限の譲渡にする
- [x] 管理者権限の譲渡が選ばれたら確認ダイアログを表示する
- [x] 確認ダイアログで「はい」が選ばれたらデータベースのチームフィールドのadminを変更する