### PR TITLE
管理者を譲れるようにします

### DIFF
--- a/lib/Pages/TeamPage/team_page.dart
+++ b/lib/Pages/TeamPage/team_page.dart
@@ -74,22 +74,35 @@ class TeamPageState extends State<TeamPage> {
                   showDialog<dynamic>(
                     context: context,
                     builder: (context) {
-                      return AlertDialog(
-                        content: Text("「" + _teamName + "」" + "を抜けますか?"),
-                        actions: <Widget>[
-                          FlatButton(
+                      if (isAdmin) {
+                        return AlertDialog(
+                          title: Text("管理者はチームから抜けられません"),
+                          content: Text("チームメンバーに管理者権限を渡してください"),
+                          actions: <Widget>[
+                            FlatButton(
                               child: Text("はい"),
-                              onPressed: () {
-                                LeaveTeam();
-                                int count = 0;
-                                Navigator.of(context).popUntil((_) => count++ >= 2);
-                              }),
-                          FlatButton(
-                            child: Text("キャンセル"),
-                            onPressed: () => Navigator.pop(context),
-                          ),
-                        ],
-                      );
+                              onPressed: () => Navigator.pop(context),
+                            ),
+                          ],
+                        );
+                      } else {
+                        return AlertDialog(
+                          content: Text("「" + _teamName + "」" + "を抜けますか?"),
+                          actions: <Widget>[
+                            FlatButton(
+                                child: Text("はい"),
+                                onPressed: () {
+                                  LeaveTeam();
+                                  int count = 0;
+                                  Navigator.of(context).popUntil((_) => count++ >= 2);
+                                }),
+                            FlatButton(
+                              child: Text("キャンセル"),
+                              onPressed: () => Navigator.pop(context),
+                            ),
+                          ],
+                        );
+                      }
                     },
                   );
                 },

--- a/lib/Pages/TeamPage/team_page.dart
+++ b/lib/Pages/TeamPage/team_page.dart
@@ -28,7 +28,10 @@ class TeamPageState extends State<TeamPage> {
         if (!adminSnapshot.hasData) {
           return Text('Loading...');
         }
+
         bool isAdmin = userData.userEmail == adminSnapshot.data['admin'].toString();
+        int _userNum = adminSnapshot.data['user_num'] as int;
+
         return Scaffold(
           appBar: AppBar(
             title: Text(_teamName),
@@ -74,34 +77,53 @@ class TeamPageState extends State<TeamPage> {
                   showDialog<dynamic>(
                     context: context,
                     builder: (context) {
-                      if (isAdmin) {
+                      if (_userNum == 1) {
                         return AlertDialog(
-                          title: Text("管理者はチームから抜けられません"),
-                          content: Text("チームメンバーに管理者権限を渡してください"),
+                          content: Text('あなたがチームを抜けると「' + _teamName + '」が削除されます。\n よろしいですか？'),
                           actions: <Widget>[
                             FlatButton(
-                              child: Text("はい"),
+                                child: Text("はい"),
+                                onPressed: () {
+                                  DeleteTeam();
+                                  int count = 0;
+                                  Navigator.of(context).popUntil((_) => count++ >= 2);
+                                }),
+                            FlatButton(
+                              child: Text('キャンセル'),
                               onPressed: () => Navigator.pop(context),
                             ),
                           ],
                         );
                       } else {
-                        return AlertDialog(
-                          content: Text("「" + _teamName + "」" + "を抜けますか?"),
-                          actions: <Widget>[
-                            FlatButton(
-                                child: Text("はい"),
-                                onPressed: () {
-                                  LeaveTeam();
-                                  int count = 0;
-                                  Navigator.of(context).popUntil((_) => count++ >= 2);
-                                }),
-                            FlatButton(
-                              child: Text("キャンセル"),
-                              onPressed: () => Navigator.pop(context),
-                            ),
-                          ],
-                        );
+                        if (isAdmin) {
+                          return AlertDialog(
+                            title: Text('管理者はチームから抜けられません'),
+                            content: Text('チームメンバーに管理者権限を渡してください'),
+                            actions: <Widget>[
+                              FlatButton(
+                                child: Text('はい'),
+                                onPressed: () => Navigator.pop(context),
+                              ),
+                            ],
+                          );
+                        } else {
+                          return AlertDialog(
+                            content: Text("「" + _teamName + "」" + "を抜けますか?"),
+                            actions: <Widget>[
+                              FlatButton(
+                                  child: Text("はい"),
+                                  onPressed: () {
+                                    LeaveTeam();
+                                    int count = 0;
+                                    Navigator.of(context).popUntil((_) => count++ >= 2);
+                                  }),
+                              FlatButton(
+                                child: Text("キャンセル"),
+                                onPressed: () => Navigator.pop(context),
+                              ),
+                            ],
+                          );
+                        }
                       }
                     },
                   );
@@ -205,5 +227,13 @@ class TeamPageState extends State<TeamPage> {
     membersEmails.forEach((var memberEmail) {
       Firestore.instance.collection('users').document(memberEmail).collection('teams').document(_teamName).delete();
     });
+  }
+
+  Future<bool> CheckIsLastmenber() async {
+    // チームの参加人数を取得
+    QuerySnapshot snapshot =
+        await Firestore.instance.collection('teams').document(_teamName).collection('users').getDocuments();
+
+    return snapshot.documents.length == 1;
   }
 }


### PR DESCRIPTION
# バックログアイテムの情報
#185 

作成者：@tyanio

## タスク
- [x] 管理者がチームから抜けるボタンを押したときにダイアログを出して前ページに戻す
- [x] メンバーが一人の時にチームを抜けるとチームを消す
