### PR TITLE
管理者はチームメンバーを追放することができる

### DIFF
--- a/lib/Pages/TeamPage/members_record.dart
+++ b/lib/Pages/TeamPage/members_record.dart
@@ -288,7 +288,7 @@ class MembersRecord extends StatelessWidget {
         FlatButton(
             child: Text("はい"),
             onPressed: () {
-//              banMember(userEmail);
+              banMember(userEmail);
               Navigator.pop(context);
             }),
         FlatButton(
@@ -299,7 +299,14 @@ class MembersRecord extends StatelessWidget {
     );
   }
 
-  void changeAdmin(String userEmail) async {
+  void changeAdmin(String userEmail){
     Firestore.instance.collection('teams').document(_teamName).updateData(<String, String>{'admin': userEmail});
+  }
+
+  void banMember(String userEmail){
+    // teamNameの中のUsersからuserEmailを削除
+    Firestore.instance.collection('teams').document(_teamName).collection('users').document(userEmail).delete();
+    // userEmailの中のTeamsからteamNameを削除
+    Firestore.instance.collection('users').document(userEmail).collection('teams').document(_teamName).delete();
   }
 }

--- a/lib/Pages/TeamPage/members_record.dart
+++ b/lib/Pages/TeamPage/members_record.dart
@@ -10,7 +10,7 @@ class MembersRecord extends StatelessWidget {
   String _teamName;
   String _adminEmail;
   // ポップアップメニューボタンの選択肢リスト
-  var _States = ['管理者の譲渡'];
+  var _States = ['管理者の譲渡', 'メンバーを追放'];
 
   MembersRecord(this._teamName, this._adminEmail);
 
@@ -143,7 +143,13 @@ class MembersRecord extends StatelessWidget {
                                                   showDialog<dynamic>(
                                                     context: context,
                                                     builder: (context) {
-                                                      return showChangeAdminDialog(context, userEmail, userName);
+                                                      if(s == '管理者の譲渡') {
+                                                        return showChangeAdminDialog(context, userEmail, userName);
+                                                      } else if(s == 'メンバーを追放'){
+                                                        return showBanDialog(context, userEmail, userName);
+                                                      } else{
+                                                        return null;
+                                                      }
                                                     },
                                                   );
                                                   print(userEmail);
@@ -265,6 +271,24 @@ class MembersRecord extends StatelessWidget {
             child: Text("はい"),
             onPressed: () {
               changeAdmin(userEmail);
+              Navigator.pop(context);
+            }),
+        FlatButton(
+          child: Text("キャンセル"),
+          onPressed: () => Navigator.pop(context),
+        ),
+      ],
+    );
+  }
+
+  Widget showBanDialog(BuildContext context, String userEmail, String userName){
+    return AlertDialog(
+      content: Text(userName + 'を追放しますか？'),
+      actions: <Widget>[
+        FlatButton(
+            child: Text("はい"),
+            onPressed: () {
+//              banMember(userEmail);
               Navigator.pop(context);
             }),
         FlatButton(


### PR DESCRIPTION
# バックログアイテムの情報
#197 

作成者：@Yamakatsu63

## タスク
- [x] メンバーページ内の各メンバーのポップアップに「メンバーを追放」という選択肢を追加する
- [x] 「メンバーを追放」が選択されたら確認のダイアログを表示する
- [x] メンバー追放が確定されたらデータベースからメンバーを追放する
  - [x] teamのusersからメンバーを削除する
  - [x] userのteamsからチームを削除する