### PR TITLE
hasNewChatをチーム参加・作成時に登録するようにしました

### DIFF
--- a/lib/Pages/LookupTeamPage/join_button.dart
+++ b/lib/Pages/LookupTeamPage/join_button.dart
@@ -1,10 +1,10 @@
-import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:the4thdayofmikkabozu/user_data.dart' as userData;
+import 'package:flutter/material.dart';
+import 'package:the4thdayofmikkabozu/user_data.dart' as user_data;
 
 class JoinButton extends StatelessWidget {
-  String _teamName;
-  String _email = userData.userEmail;
+  final String _teamName;
+  final String _email = user_data.userEmail;
 
   JoinButton(this._teamName) : super();
 
@@ -23,14 +23,14 @@ class JoinButton extends StatelessWidget {
     );
   }
 
-  void _joinTeam() async {
+  Future<void> _joinTeam() async {
     //teamに自分の情報を追加
     Firestore.instance
         .collection('teams')
         .document(_teamName)
         .collection('users')
         .document(_email)
-        .setData(<String, dynamic>{'email': _email, 'name': userData.userName});
+        .setData(<String, dynamic>{'email': _email, 'name': user_data.userName});
 
     //自分の情報にチームの情報を追加
     Firestore.instance
@@ -39,18 +39,12 @@ class JoinButton extends StatelessWidget {
         .collection('teams')
         .document(_teamName)
         .setData(<String, dynamic>{'team_name': _teamName});
-    
+
     // チームの参加人数を取得
-    DocumentSnapshot snapshot = await Firestore.instance
-        .collection('teams')
-        .document(_teamName)
-        .get();
-    
+    final DocumentSnapshot snapshot = await Firestore.instance.collection('teams').document(_teamName).get();
+
     // チームの参加人数を1増やしてプッシュ
-    int userNum = (snapshot.data['user_num'] as int) + 1;
-    Firestore.instance
-      .collection('teams')
-      .document(_teamName)
-      .updateData(<String, num>{'user_num': userNum});
+    final int userNum = (snapshot.data['user_num'] as int) + 1;
+    Firestore.instance.collection('teams').document(_teamName).updateData(<String, num>{'user_num': userNum});
   }
 }

--- a/lib/Pages/LookupTeamPage/join_button.dart
+++ b/lib/Pages/LookupTeamPage/join_button.dart
@@ -14,9 +14,12 @@ class JoinButton extends StatelessWidget {
       child: FlatButton(
           child: const Text('参加'),
           textColor: Theme.of(context).primaryColor,
-          onPressed: () async {
+          onPressed: () {
             //チームに参加
-            await _joinTeam();
+            _joinTeam();
+            // hasNewChatの辞書に追加
+            // 入った最初からChatの赤ぽちあるのも変な話なので初期値はFalseにしておく
+            user_data.hasNewChat[_teamName] = false;
             //前のページに戻る
             Navigator.pop(context);
           }),
@@ -50,9 +53,5 @@ class JoinButton extends StatelessWidget {
     // チームの参加人数を1増やしてプッシュ
     final int userNum = (snapshot.data['user_num'] as int) + 1;
     Firestore.instance.collection('teams').document(_teamName).updateData(<String, num>{'user_num': userNum});
-
-    // hasNewChatの辞書に追加
-    // 入った最初からChatの赤ぽちあるのも変な話なので初期値はFalseにしておく
-    user_data.hasNewChat[_teamName] = false;
   }
 }

--- a/lib/Pages/LookupTeamPage/join_button.dart
+++ b/lib/Pages/LookupTeamPage/join_button.dart
@@ -16,7 +16,7 @@ class JoinButton extends StatelessWidget {
           textColor: Theme.of(context).primaryColor,
           onPressed: () async {
             //チームに参加
-            _joinTeam();
+            await _joinTeam();
             //前のページに戻る
             Navigator.pop(context);
           }),

--- a/lib/Pages/LookupTeamPage/join_button.dart
+++ b/lib/Pages/LookupTeamPage/join_button.dart
@@ -32,13 +32,17 @@ class JoinButton extends StatelessWidget {
         .document(_email)
         .setData(<String, dynamic>{'email': _email, 'name': user_data.userName});
 
-    //自分の情報にチームの情報を追加
+    // 自分の情報にチームの情報を追加
+    // last_visitedもここで現在時間を追加する
     Firestore.instance
         .collection('users')
         .document(_email)
         .collection('teams')
         .document(_teamName)
-        .setData(<String, dynamic>{'team_name': _teamName});
+        .setData(<String, dynamic>{
+      'team_name': _teamName,
+      'last_visited': Timestamp.now(),
+    });
 
     // チームの参加人数を取得
     final DocumentSnapshot snapshot = await Firestore.instance.collection('teams').document(_teamName).get();
@@ -46,5 +50,9 @@ class JoinButton extends StatelessWidget {
     // チームの参加人数を1増やしてプッシュ
     final int userNum = (snapshot.data['user_num'] as int) + 1;
     Firestore.instance.collection('teams').document(_teamName).updateData(<String, num>{'user_num': userNum});
+
+    // hasNewChatの辞書に追加
+    // 入った最初からChatの赤ぽちあるのも変な話なので初期値はFalseにしておく
+    user_data.hasNewChat[_teamName] = false;
   }
 }

--- a/lib/Pages/TeamCreatePage/team_create_page.dart
+++ b/lib/Pages/TeamCreatePage/team_create_page.dart
@@ -1,7 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:fluttertoast/fluttertoast.dart';
-import 'package:the4thdayofmikkabozu/user_data.dart' as userData;
+import 'package:the4thdayofmikkabozu/user_data.dart' as user_data;
 
 class TeamCreatePage extends StatefulWidget {
   final String title = 'チーム作成';
@@ -11,7 +11,7 @@ class TeamCreatePage extends StatefulWidget {
 }
 
 class TeamCreatePageState extends State<TeamCreatePage> {
-  String _email = userData.userEmail;
+  final String _email = user_data.userEmail;
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
   final TextEditingController _nameController = TextEditingController();
   final TextEditingController _overviewController = TextEditingController();
@@ -34,8 +34,7 @@ class TeamCreatePageState extends State<TeamCreatePage> {
                 children: <Widget>[
                   TextFormField(
                     controller: _nameController,
-                    decoration:
-                        const InputDecoration(labelText: 'チーム名を入力してください'),
+                    decoration: const InputDecoration(labelText: 'チーム名を入力してください'),
                     validator: (String value) {
                       if (value.isEmpty) {
                         return '登録にはチーム名が必要です';
@@ -47,8 +46,7 @@ class TeamCreatePageState extends State<TeamCreatePage> {
                   ),
                   TextFormField(
                     controller: _overviewController,
-                    decoration:
-                        const InputDecoration(labelText: 'チームの概要を入力してください'),
+                    decoration: const InputDecoration(labelText: 'チームの概要を入力してください'),
                     validator: (String value) {
                       if (value.isEmpty) {
                         return '登録にはチームの概要が必要です';
@@ -59,8 +57,7 @@ class TeamCreatePageState extends State<TeamCreatePage> {
                   TextFormField(
                     controller: _goalController,
                     keyboardType: TextInputType.number,
-                    decoration:
-                        const InputDecoration(labelText: 'チームの目標を入力してください'),
+                    decoration: const InputDecoration(labelText: 'チームの目標を入力してください'),
                     validator: (String value) {
                       if (value.isEmpty) {
                         return '登録にはチームの目標が必要です';
@@ -79,20 +76,17 @@ class TeamCreatePageState extends State<TeamCreatePage> {
                         buttonColor: Colors.white,
                         child: RaisedButton(
                           child: const Text('作成'),
-                          shape: OutlineInputBorder(
-                            borderRadius:
-                                BorderRadius.all(Radius.circular(10.0)),
+                          shape: const OutlineInputBorder(
+                            borderRadius: BorderRadius.all(Radius.circular(10.0)),
                           ),
                           onPressed: () async {
                             if (_formKey.currentState.validate()) {
-                              if (await checkUniqueTeamName(
-                                  _nameController.text)) {
+                              if (await checkUniqueTeamName(_nameController.text)) {
                                 createTeam();
                                 updateDataUserData();
                                 // 2ページ前に戻る
                                 int count = 0;
-                                Navigator.of(context)
-                                    .popUntil((_) => count++ >= 2);
+                                Navigator.of(context).popUntil((_) => count++ >= 2);
                               } else {
                                 Fluttertoast.showToast(
                                   msg: 'すでに使用されています',
@@ -113,6 +107,7 @@ class TeamCreatePageState extends State<TeamCreatePage> {
     );
   }
 
+  @override
   void dispose() {
     _nameController.dispose();
     super.dispose();
@@ -120,10 +115,7 @@ class TeamCreatePageState extends State<TeamCreatePage> {
 
   //チームを作成する関数
   void createTeam() {
-    Firestore.instance
-        .collection('teams')
-        .document(_nameController.text)
-        .setData(<String, dynamic>{
+    Firestore.instance.collection('teams').document(_nameController.text).setData(<String, dynamic>{
       'team_name': _nameController.text,
       'goal': int.parse(_goalController.text),
       'team_overview': _overviewController.text,
@@ -154,11 +146,9 @@ class TeamCreatePageState extends State<TeamCreatePage> {
   }
 
   Future<bool> checkUniqueTeamName(String candidateName) async {
-    var docs = await Firestore.instance
-        .collection("teams")
-        .where("team_name", isEqualTo: candidateName)
-        .getDocuments();
-    if (docs.documents.length == 0) {
+    final docs =
+        await Firestore.instance.collection('teams').where('team_name', isEqualTo: candidateName).getDocuments();
+    if (docs.documents.isEmpty) {
       return true;
     } else {
       return false;

--- a/lib/Pages/TeamCreatePage/team_create_page.dart
+++ b/lib/Pages/TeamCreatePage/team_create_page.dart
@@ -84,6 +84,8 @@ class TeamCreatePageState extends State<TeamCreatePage> {
                               if (await checkUniqueTeamName(_nameController.text)) {
                                 createTeam();
                                 updateDataUserData();
+                                // hasNewChatの辞書に登録する
+                                user_data.hasNewChat[_nameController.text] = false;
                                 // 2ページ前に戻る
                                 int count = 0;
                                 Navigator.of(context).popUntil((_) => count++ >= 2);
@@ -139,8 +141,9 @@ class TeamCreatePageState extends State<TeamCreatePage> {
         .collection('teams')
         .document(_nameController.text)
         .setData(<String, dynamic>{
-      'team_name': _nameController.text,
       'goal': int.parse(_goalController.text),
+      'last_visited': Timestamp.now(),
+      'team_name': _nameController.text,
       'team_overview': _overviewController.text,
     });
   }


### PR DESCRIPTION
# バックログアイテムの情報
#219 
あんまり変わらないですがブランチ名変える前のやつ→ https://github.com/cammelworks/The4thDay-of-MikkaBozu/pull/220#issue-684192588
同じことしてたのでClose→ https://github.com/cammelworks/The4thDay-of-MikkaBozu/pull/221#issue-692305298

## タスク
- [x] hasNewChatをチーム参加時登録するようにする
- [x] hasNewChatをチーム作成時登録するようにする
- [x] 赤ぽちが参加してから最初からつくのも変なのでlast_visitedの値も現在時間を登録する

## テスト
- チーム(test_hasNewChat1)に参加してチーム一覧ページが型崩れしないか確かめてください
- チーム適当に作ってチーム一覧ページが型崩れしないか確かめてください
- 起動しなおしてもチャットがある新しく参加したチーム(test_hasNewChat)が赤ぽちつかないか確かめて下し
