### PR TITLE
チャットの時間表示を修正

### DIFF
--- a/lib/Pages/ChatPage/chat_page.dart
+++ b/lib/Pages/ChatPage/chat_page.dart
@@ -198,8 +198,8 @@ class ChatPageState extends State<ChatPage> {
     DateTime dateTime = timestamp.toDate();
     String month = dateTime.month.toString();
     String day = dateTime.day.toString();
-    String hour = dateTime.hour.toString();
-    String minute = dateTime.minute.toString();
+    String hour = dateTime.hour.toString().padLeft(2, "0");
+    String minute = dateTime.minute.toString().padLeft(2, "0");
 
     return month + "/" + day + " " + hour + ":" + minute;
   }


### PR DESCRIPTION
# バックログアイテムの情報
#227

作成者：@Yamakatsu

## タスク
- [x] チャットの時間表示を2桁の0埋めに修正する

